### PR TITLE
fix EditMessageReplyMarkupConfig

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -600,7 +600,6 @@ func (config EditMessageCaptionConfig) method() string {
 // of a message.
 type EditMessageReplyMarkupConfig struct {
 	BaseEdit
-	ReplyMarkup *InlineKeyboardMarkup
 }
 
 func (config EditMessageReplyMarkupConfig) values() (url.Values, error) {

--- a/helpers.go
+++ b/helpers.go
@@ -423,8 +423,8 @@ func NewEditMessageReplyMarkup(chatID int64, messageID int, replyMarkup InlineKe
 		BaseEdit: BaseEdit{
 			ChatID:    chatID,
 			MessageID: messageID,
+			ReplyMarkup: &replyMarkup,
 		},
-		ReplyMarkup: &replyMarkup,
 	}
 }
 


### PR DESCRIPTION
```go
url := "http://www.xboston.ru"
markup := tgbotapi.InlineKeyboardMarkup{
	InlineKeyboard: [][]tgbotapi.InlineKeyboardButton{
		{
			{
				Text: "test",
				URL:  &url,
			},
		},
	},
}
edit := tgbotapi.NewEditMessageReplyMarkup(update.CallbackQuery.Message.Chat.ID, mid, markup)
bot.Send(edit)
```

before:
```
2016/04/19 12:02:28 editMessageReplyMarkup req : map[chat_id:[123] message_id:[274] inline_message_id:[]]
```
after:
```
2016/04/19 12:01:06 editMessageReplyMarkup req : map[chat_id:[123] message_id:[272] inline_message_id:[] reply_markup:[{"inline_keyboard":[[{"text":"test","url":"http://www.xboston.ru"}]]}]]
```