### PR TITLE
Add support for Markdown/HTML in NewInlineQueryResultArticle

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -501,7 +501,7 @@ func ExampleAnswerInlineQuery() {
 			continue
 		}
 
-		article := tgbotapi.NewInlineQueryResultArticle(update.InlineQuery.ID, "Echo", update.InlineQuery.Query)
+		article := tgbotapi.NewInlineQueryResultArticle(update.InlineQuery.ID, "Echo", update.InlineQuery.Query, "Markdown")
 		article.Description = update.InlineQuery.Query
 
 		inlineConf := tgbotapi.InlineConfig{

--- a/bot_test.go
+++ b/bot_test.go
@@ -501,7 +501,75 @@ func ExampleAnswerInlineQuery() {
 			continue
 		}
 
-		article := tgbotapi.NewInlineQueryResultArticle(update.InlineQuery.ID, "Echo", update.InlineQuery.Query, "Markdown")
+		article := tgbotapi.NewInlineQueryResultArticle(update.InlineQuery.ID, "Echo", update.InlineQuery.Query)
+		article.Description = update.InlineQuery.Query
+
+		inlineConf := tgbotapi.InlineConfig{
+			InlineQueryID: update.InlineQuery.ID,
+			IsPersonal:    true,
+			CacheTime:     0,
+			Results:       []interface{}{article},
+		}
+
+		if _, err := bot.AnswerInlineQuery(inlineConf); err != nil {
+			log.Println(err)
+		}
+	}
+}
+
+func ExampleAnswerInlineQueryMarkdown() {
+	bot, err := tgbotapi.NewBotAPI("MyAwesomeBotToken") // create new bot
+	if err != nil {
+		log.Panic(err)
+	}
+
+	log.Printf("Authorized on account %s", bot.Self.UserName)
+
+	u := tgbotapi.NewUpdate(0)
+	u.Timeout = 60
+
+	updates, err := bot.GetUpdatesChan(u)
+
+	for update := range updates {
+		if update.InlineQuery == nil { // if no inline query, ignore it
+			continue
+		}
+
+		article := tgbotapi.NewInlineQueryResultArticleMarkdown(update.InlineQuery.ID, "Echo", update.InlineQuery.Query)
+		article.Description = update.InlineQuery.Query
+
+		inlineConf := tgbotapi.InlineConfig{
+			InlineQueryID: update.InlineQuery.ID,
+			IsPersonal:    true,
+			CacheTime:     0,
+			Results:       []interface{}{article},
+		}
+
+		if _, err := bot.AnswerInlineQuery(inlineConf); err != nil {
+			log.Println(err)
+		}
+	}
+}
+
+func ExampleAnswerInlineQueryHTML() {
+	bot, err := tgbotapi.NewBotAPI("MyAwesomeBotToken") // create new bot
+	if err != nil {
+		log.Panic(err)
+	}
+
+	log.Printf("Authorized on account %s", bot.Self.UserName)
+
+	u := tgbotapi.NewUpdate(0)
+	u.Timeout = 60
+
+	updates, err := bot.GetUpdatesChan(u)
+
+	for update := range updates {
+		if update.InlineQuery == nil { // if no inline query, ignore it
+			continue
+		}
+
+		article := tgbotapi.NewInlineQueryResultArticleHTML(update.InlineQuery.ID, "Echo", update.InlineQuery.Query)
 		article.Description = update.InlineQuery.Query
 
 		inlineConf := tgbotapi.InlineConfig{

--- a/helpers.go
+++ b/helpers.go
@@ -317,14 +317,39 @@ func NewWebhookWithCert(link string, file interface{}) WebhookConfig {
 }
 
 // NewInlineQueryResultArticle creates a new inline query article.
-func NewInlineQueryResultArticle(id, title, messageText string, parseMode string) InlineQueryResultArticle {
+func NewInlineQueryResultArticle(id, title, messageText string) InlineQueryResultArticle {
 	return InlineQueryResultArticle{
 		Type:  "article",
 		ID:    id,
 		Title: title,
 		InputMessageContent: InputTextMessageContent{
 			Text: messageText,
-			ParseMode: parseMode,
+		},
+	}
+}
+
+// NewInlineQueryResultArticleMarkdown creates a new inline query article with Markdown parsing.
+func NewInlineQueryResultArticleMarkdown(id, title, messageText string) InlineQueryResultArticle {
+	return InlineQueryResultArticle{
+		Type:  "article",
+		ID:    id,
+		Title: title,
+		InputMessageContent: InputTextMessageContent{
+			Text: messageText,
+			ParseMode: "Markdown",
+		},
+	}
+}
+
+// NewInlineQueryResultArticleHTML creates a new inline query article with HTML parsing.
+func NewInlineQueryResultArticleHTML(id, title, messageText string) InlineQueryResultArticle {
+	return InlineQueryResultArticle{
+		Type:  "article",
+		ID:    id,
+		Title: title,
+		InputMessageContent: InputTextMessageContent{
+			Text: messageText,
+			ParseMode: "HTML",
 		},
 	}
 }

--- a/helpers.go
+++ b/helpers.go
@@ -317,13 +317,14 @@ func NewWebhookWithCert(link string, file interface{}) WebhookConfig {
 }
 
 // NewInlineQueryResultArticle creates a new inline query article.
-func NewInlineQueryResultArticle(id, title, messageText string) InlineQueryResultArticle {
+func NewInlineQueryResultArticle(id, title, messageText string, parseMode string) InlineQueryResultArticle {
 	return InlineQueryResultArticle{
 		Type:  "article",
 		ID:    id,
 		Title: title,
 		InputMessageContent: InputTextMessageContent{
 			Text: messageText,
+			ParseMode: parseMode,
 		},
 	}
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -6,13 +6,36 @@ import (
 )
 
 func TestNewInlineQueryResultArticle(t *testing.T) {
-	result := tgbotapi.NewInlineQueryResultArticle("id", "title", "message", "Markdown")
+	result := tgbotapi.NewInlineQueryResultArticle("id", "title", "message")
 
 	if result.Type != "article" ||
 		result.ID != "id" ||
 		result.Title != "title" ||
-		result.InputMessageContent.(tgbotapi.InputTextMessageContent).Text != "message" ||
+		result.InputMessageContent.(tgbotapi.InputTextMessageContent).Text != "message" {
+		t.Fail()
+	}
+}
+
+func TestNewInlineQueryResultArticleMarkdown(t *testing.T) {
+	result := tgbotapi.NewInlineQueryResultArticleMarkdown("id", "title", "*message*")
+
+	if result.Type != "article" ||
+		result.ID != "id" ||
+		result.Title != "title" ||
+		result.InputMessageContent.(tgbotapi.InputTextMessageContent).Text != "*message*" ||
 		result.InputMessageContent.(tgbotapi.InputTextMessageContent).ParseMode != "Markdown" {
+		t.Fail()
+	}
+}
+
+func TestNewInlineQueryResultArticleHTML(t *testing.T) {
+	result := tgbotapi.NewInlineQueryResultArticleHTML("id", "title", "<b>message</b>")
+
+	if result.Type != "article" ||
+		result.ID != "id" ||
+		result.Title != "title" ||
+		result.InputMessageContent.(tgbotapi.InputTextMessageContent).Text != "<b>message</b>" ||
+		result.InputMessageContent.(tgbotapi.InputTextMessageContent).ParseMode != "HTML" {
 		t.Fail()
 	}
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -6,12 +6,13 @@ import (
 )
 
 func TestNewInlineQueryResultArticle(t *testing.T) {
-	result := tgbotapi.NewInlineQueryResultArticle("id", "title", "message")
+	result := tgbotapi.NewInlineQueryResultArticle("id", "title", "message", "Markdown")
 
 	if result.Type != "article" ||
 		result.ID != "id" ||
 		result.Title != "title" ||
-		result.InputMessageContent.(tgbotapi.InputTextMessageContent).Text != "message" {
+		result.InputMessageContent.(tgbotapi.InputTextMessageContent).Text != "message" ||
+		result.InputMessageContent.(tgbotapi.InputTextMessageContent).ParseMode != "Markdown" {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
I'm not sure if this solution is correct (newb in Golang), but it looks like works :)
Adds fourth arg to NewInlineQueryResultArticle, which can be "Markdown", "HTML" or "" (empty string for no parse).