### PR TITLE
Fixed BaseEdit.values

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -166,13 +166,16 @@ type BaseEdit struct {
 func (edit BaseEdit) values() (url.Values, error) {
 	v := url.Values{}
 
-	if edit.ChannelUsername != "" {
-		v.Add("chat_id", edit.ChannelUsername)
+	if edit.InlineMessageID == "" {
+		if edit.ChannelUsername != "" {
+			v.Add("chat_id", edit.ChannelUsername)
+		} else {
+			v.Add("chat_id", strconv.FormatInt(edit.ChatID, 10))
+		}
+		v.Add("message_id", strconv.Itoa(edit.MessageID))
 	} else {
-		v.Add("chat_id", strconv.FormatInt(edit.ChatID, 10))
+		v.Add("inline_message_id", edit.InlineMessageID)
 	}
-	v.Add("message_id", strconv.Itoa(edit.MessageID))
-	v.Add("inline_message_id", edit.InlineMessageID)
 
 	if edit.ReplyMarkup != nil {
 		data, err := json.Marshal(edit.ReplyMarkup)


### PR DESCRIPTION
chat_id and message_id should be sent only if there is no
inline_message_id (and vice versa), according to documentation.
Without this change it is impossible to edit a message by InlineMessageID, because chat_id and message_id are always presented in a query and the Telegram server tries to use them instead of InlineMessageID