### PR TITLE
Added updatesChannel type with Clear() method

### DIFF
--- a/types.go
+++ b/types.go
@@ -37,6 +37,16 @@ type Update struct {
 	CallbackQuery      *CallbackQuery      `json:"callback_query"`
 }
 
+//updatesChannel is the channel for getting updates.
+type updatesChannel <-chan Update
+
+//Clear discards all the actual incoming updates
+func (ch updatesChannel) Clear() {
+	for len(ch) != 0 {
+		<-ch
+	}
+}
+
 // User is a user on Telegram.
 type User struct {
 	ID        int    `json:"id"`


### PR DESCRIPTION
I wanted to have an elegant way to clear the updates in the updates channel. The channel works as a normal channel just adding a callable method
Here an example of the Clear() method working:
```
updates, err := bot.GetUpdatesChan(u)

//waits to gather all the new updates
time.Sleep(time.Millisecond * 500)

//discards all the updates preventing the spam after your server been down
updates.Clear()

//process new updates
for update := range updates {
	if update.Message == nil {
		continue
}
```

Note: the change on the position of "github.com/technoweenie/multipartstreamer" in the import has been made automatically by the Go tooling of code analysis.