### PR TITLE
Fix InlineKeyboardButton type

### DIFF
--- a/types.go
+++ b/types.go
@@ -356,11 +356,11 @@ type InlineKeyboardMarkup struct {
 // CallbackGame, if set, MUST be first button in first row.
 type InlineKeyboardButton struct {
 	Text                         string        `json:"text"`
-	URL                          *string       `json:"url,omitempty"`                    // optional
-	CallbackData                 *string       `json:"callback_data,omitempty"`          // optional
-	SwitchInlineQuery            *string       `json:"switch_inline_query,omitempty"`    // optional
-	SwitchInlineQueryCurrentChat *string       `json:"switch_inline_query_current_chat"` // optional
-	CallbackGame                 *CallbackGame `json:"callback_game"`                    // optional
+	URL                          *string       `json:"url,omitempty"`                              // optional
+	CallbackData                 *string       `json:"callback_data,omitempty"`                    // optional
+	SwitchInlineQuery            *string       `json:"switch_inline_query,omitempty"`              // optional
+	SwitchInlineQueryCurrentChat *string       `json:"switch_inline_query_current_chat,omitempty"` // optional
+	CallbackGame                 *CallbackGame `json:"callback_game,omitempty"`                    // optional
 }
 
 // CallbackQuery is data sent when a keyboard button with callback data


### PR DESCRIPTION
`SwitchInlineQueryCurrentChat` and `CallbackGame` were missing `omitempty` attribute and creating a button without them failed with BUTTON_TYPE_INVALID.