### PR TITLE
Fix returning APIResponse from SetWebHook

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -184,7 +184,11 @@ func (bot *BotAPI) UploadFile(endpoint string, params map[string]string, fieldna
 	}
 
 	var apiResp APIResponse
-	json.Unmarshal(bytes, &apiResp)
+
+	err = json.Unmarshal(bytes, &apiResp)
+	if err != nil {
+		return APIResponse{}, err
+	}
 
 	if !apiResp.Ok {
 		return APIResponse{}, errors.New(apiResp.Description)
@@ -431,14 +435,7 @@ func (bot *BotAPI) SetWebhook(config WebhookConfig) (APIResponse, error) {
 		return APIResponse{}, err
 	}
 
-	var apiResp APIResponse
-	json.Unmarshal(resp.Result, &apiResp)
-
-	if bot.Debug {
-		log.Printf("setWebhook resp: %+v\n", apiResp)
-	}
-
-	return apiResp, nil
+	return resp, nil
 }
 
 // GetWebhookInfo allows you to fetch information about a webhook and if


### PR DESCRIPTION
UploadFile returns APIResponce. After that in SetWebHook you try Unmarshal APIResponse.result to APIResponse!

In UploadFile line 186:

    var apiResp APIResponse
    json.Unmarshal(bytes, &apiResp)
    
    if !apiResp.Ok {
        return APIResponse{}, errors.New(apiResp.Description)
    }
    
    return apiResp, ni

And in SetWebHook line 429:

    resp, err := bot.UploadFile("setWebhook", params, "certificate", config.Certificate)
    if err != nil {
        return APIResponse{}, err
    }
    
    var apiResp APIResponse
    json.Unmarshal(resp.Result, &apiResp)

I remove unneeded Unmarshal and return just a resp.