### PR TITLE
Rewrite message command methods to use entities

### DIFF
--- a/types_test.go
+++ b/types_test.go
@@ -91,10 +91,27 @@ func TestCommandWithBotName(t *testing.T) {
 	}
 }
 
+func TestCommandWithAtWithBotName(t *testing.T) {
+	message := tgbotapi.Message{Text: "/command@testbot"}
+	message.Entities = &[]tgbotapi.MessageEntity{{Type: "bot_command", Offset: 0, Length: 16}}
+
+	if message.CommandWithAt() != "command@testbot" {
+		t.Fail()
+	}
+}
+
 func TestMessageCommandArgumentsWithArguments(t *testing.T) {
 	message := tgbotapi.Message{Text: "/command with arguments"}
 	message.Entities = &[]tgbotapi.MessageEntity{{Type: "bot_command", Offset: 0, Length: 8}}
 	if message.CommandArguments() != "with arguments" {
+		t.Fail()
+	}
+}
+
+func TestMessageCommandArgumentsWithMalformedArguments(t *testing.T) {
+	message := tgbotapi.Message{Text: "/command-without argument space"}
+	message.Entities = &[]tgbotapi.MessageEntity{{Type: "bot_command", Offset: 0, Length: 8}}
+	if message.CommandArguments() != "without argument space" {
 		t.Fail()
 	}
 }

--- a/types_test.go
+++ b/types_test.go
@@ -34,6 +34,7 @@ func TestMessageTime(t *testing.T) {
 
 func TestMessageIsCommandWithCommand(t *testing.T) {
 	message := tgbotapi.Message{Text: "/command"}
+	message.Entities = &[]tgbotapi.MessageEntity{{Type: "bot_command", Offset: 0, Length: 8}}
 
 	if message.IsCommand() != true {
 		t.Fail()
@@ -58,6 +59,7 @@ func TestIsCommandWithEmptyText(t *testing.T) {
 
 func TestCommandWithCommand(t *testing.T) {
 	message := tgbotapi.Message{Text: "/command"}
+	message.Entities = &[]tgbotapi.MessageEntity{{Type: "bot_command", Offset: 0, Length: 8}}
 
 	if message.Command() != "command" {
 		t.Fail()
@@ -82,6 +84,7 @@ func TestCommandWithNonCommand(t *testing.T) {
 
 func TestCommandWithBotName(t *testing.T) {
 	message := tgbotapi.Message{Text: "/command@testbot"}
+	message.Entities = &[]tgbotapi.MessageEntity{{Type: "bot_command", Offset: 0, Length: 16}}
 
 	if message.Command() != "command" {
 		t.Fail()
@@ -90,6 +93,7 @@ func TestCommandWithBotName(t *testing.T) {
 
 func TestMessageCommandArgumentsWithArguments(t *testing.T) {
 	message := tgbotapi.Message{Text: "/command with arguments"}
+	message.Entities = &[]tgbotapi.MessageEntity{{Type: "bot_command", Offset: 0, Length: 8}}
 	if message.CommandArguments() != "with arguments" {
 		t.Fail()
 	}


### PR DESCRIPTION
For (possibly) malformed commands, the old implementation gives results which are inconsistent with what you'd expect from the message entities, which are generated by the Telegram API.

For messages "/foo bar" and "/foo-bar":
![output](https://user-images.githubusercontent.com/2729584/31309307-5fb62056-ab84-11e7-96a2-9c877ebcd6f5.png)
(Here, "Remainder" denotes the substring immediately following the command entity. It's not necessarily useful)

I also added a version of Command() which does not strip the _@User_ suffix. To me, the old version suggest that only a bot's name was stripped when actually any _@something_ suffix was removed. I hope that this solution elegantly emphasizes this fact.

Since the Telegram-API considers "/foo-bar" to be a command entity
"/foo", we had choose a behaviour for the
CommandArguments() method.
The specification (https://core.telegram.org/bots#commands) mandates a
space after the command name, so we decided to skip the first character
following the command entity.
However, Telegram clients render "/foo-bar" as if "/foo" was the command
and "-bar" additional text, so this alternative should be remembered.