### PR TITLE
[proposal]check telegram webhook tls handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,13 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
+	info, err := bot.GetWebhookInfo()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if info.LastErrorDate != 0 {
+		log.Printf("[Telegram callback failed]%s", info.LastErrorMessage)
+	}
 	updates := bot.ListenForWebhook("/" + bot.Token)
 	go http.ListenAndServeTLS("0.0.0.0:8443", "cert.pem", "key.pem", nil)
 

--- a/bot_test.go
+++ b/bot_test.go
@@ -467,7 +467,13 @@ func TestSetWebhookWithCert(t *testing.T) {
 		t.Error(err)
 		t.Fail()
 	}
-
+	info, err := bot.GetWebhookInfo()
+	if err != nil {
+		t.Error(err)
+	}
+	if info.LastErrorDate != 0 {
+		t.Errorf("[Telegram callback failed]%s", info.LastErrorMessage)
+	}
 	bot.RemoveWebhook()
 }
 
@@ -484,7 +490,13 @@ func TestSetWebhookWithoutCert(t *testing.T) {
 		t.Error(err)
 		t.Fail()
 	}
-
+	info, err := bot.GetWebhookInfo()
+	if err != nil {
+		t.Error(err)
+	}
+	if info.LastErrorDate != 0 {
+		t.Errorf("[Telegram callback failed]%s", info.LastErrorMessage)
+	}
 	bot.RemoveWebhook()
 }
 
@@ -549,7 +561,13 @@ func ExampleNewWebhook() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
+	info, err := bot.GetWebhookInfo()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if info.LastErrorDate != 0 {
+		log.Printf("[Telegram callback failed]%s", info.LastErrorMessage)
+	}
 	updates := bot.ListenForWebhook("/" + bot.Token)
 	go http.ListenAndServeTLS("0.0.0.0:8443", "cert.pem", "key.pem", nil)
 


### PR DESCRIPTION
I think we should handle the error when the handshake from telegram server failed .This func will help us check whether the webhook is ok ,and telegram can correctly communicate with us.Once,I set the wrong cert by mistake, but the log shows that my webhook was set.When I debug my program I find that the TLS handshake from telegram failed.

So, we'd better to add the `GetWebHookInfo()` in our sample(test) code to avoid this kind of bug . 