### PR TITLE
Add helper function NewDeleteMessage

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -19,6 +19,13 @@ func NewMessage(chatID int64, text string) MessageConfig {
 	}
 }
 
+func NewDeleteMessage(chatID int64, messageID int) DeleteMessageConfig {
+	return DeleteMessageConfig{
+		ChatID:    chatID,
+		MessageID: messageID,
+	}
+}
+
 // NewMessageToChannel creates a new Message that is sent to a channel
 // by username.
 //


### PR DESCRIPTION
I found that deleteMessageConfig is added. But the helper function is not, this patch adds one.
Signed-off-by: Jianqiu Zhang <zhangjianqiu13@gmail.com>