### PR TITLE
Gather webhook information from a http request

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -427,7 +427,7 @@ func (bot *BotAPI) GetUpdates(config UpdateConfig) ([]Update, error) {
 	return updates, nil
 }
 
-// Remove unsets the webhook.
+// RemoveWebhook unsets the webhook.
 func (bot *BotAPI) RemoveWebhook() (APIResponse, error) {
 	return bot.MakeRequest("setWebhook", url.Values{})
 }

--- a/bot.go
+++ b/bot.go
@@ -427,7 +427,7 @@ func (bot *BotAPI) GetUpdates(config UpdateConfig) ([]Update, error) {
 	return updates, nil
 }
 
-// RemoveWebhook unsets the webhook.
+// Remove unsets the webhook.
 func (bot *BotAPI) RemoveWebhook() (APIResponse, error) {
 	return bot.MakeRequest("setWebhook", url.Values{})
 }
@@ -505,17 +505,25 @@ func (bot *BotAPI) GetUpdatesChan(config UpdateConfig) (UpdatesChannel, error) {
 	return ch, nil
 }
 
+//GetWebhookUpdate gathers webhook information from a http.Request
+func GetWebhookUpdate(r *http.Request) (*Update, error) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	
+	var update Update
+	err = json.Unmarshal(b, &update)	
+	return &update, err
+}
+
 // ListenForWebhook registers a http handler for a webhook.
 func (bot *BotAPI) ListenForWebhook(pattern string) UpdatesChannel {
 	ch := make(chan Update, bot.Buffer)
 
 	http.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
-		bytes, _ := ioutil.ReadAll(r.Body)
-
-		var update Update
-		json.Unmarshal(bytes, &update)
-
-		ch <- update
+		update, _ := GetWebhookUpdate(r)
+		ch <- *update
 	})
 
 	return ch


### PR DESCRIPTION
This pull request adds a new method `GetWebhookUpdate` and is represents an abstraction of most of the content of `ListenForWebhook`.
`GetWebhookUpdate` uses a `http.Request` to read out and return neccessary information from the request. Thus, it can be used in any http scenario and can be integrated very simple.
Moreover, `GetWebhookUpdate` returns an error to check for.