### PR TITLE
Add go.mod in order to allow semantic import versioning

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/go-telegram-bot-api/telegram-bot-api/v4"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/go-telegram-bot-api/telegram-bot-api/v4
+
+require github.com/technoweenie/multipartstreamer v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/technoweenie/multipartstreamer v1.0.1 h1:XRztA5MXiR1TIRHxH2uNxXxaIkKQDeX7m2XsSOlQEnM=
+github.com/technoweenie/multipartstreamer v1.0.1/go.mod h1:jNVxdtShOxzAsukZwTSw6MDx5eUJoiEBsSvzDU9uzog=

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,8 +1,9 @@
 package tgbotapi_test
 
 import (
-	"github.com/go-telegram-bot-api/telegram-bot-api"
 	"testing"
+
+	"github.com/go-telegram-bot-api/telegram-bot-api/v4"
 )
 
 func TestNewInlineQueryResultArticle(t *testing.T) {

--- a/types_test.go
+++ b/types_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/go-telegram-bot-api/telegram-bot-api/v4"
 )
 
 func TestUserStringWith(t *testing.T) {


### PR DESCRIPTION
As the latest version is tagged as v4.x.x in git, using the package as a Go module will require importing it as github.com/go-telegram-bot-api/telegram-bot-api/v4, otherwise it will show up as:

github.com/go-telegram-bot-api/telegram-bot-api v4.6.2+incompatible
in a dependent's go.mod.

See: https://github.com/golang/go/wiki/Modules#semantic-import-versioning