### PR TITLE
Provide users with more customization when creating a new bot.

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -34,7 +34,7 @@ type BotAPI struct {
 //
 // It requires a token, provided by @BotFather on Telegram.
 func NewBotAPI(token string) (*BotAPI, error) {
-	return CreateNewBotApi(token, &http.Client{}, false)
+	return CreateNewBotAPI(token, &http.Client{}, false)
 }
 
 // NewBotAPIWithClient creates a new BotAPI instance
@@ -42,22 +42,22 @@ func NewBotAPI(token string) (*BotAPI, error) {
 //
 // It requires a token, provided by @BotFather on Telegram.
 func NewBotAPIWithClient(token string, client *http.Client) (*BotAPI, error) {
-	return CreateNewBotApi(token, client, false)
+	return CreateNewBotAPI(token, client, false)
 }
 
-// NewBotAPIWithClient creates a new BotAPI instance
+// NewBotAPIWithDebug creates a new BotAPI instance
 // and enables debug by default.
 //
 // It requires a token, provided by @BotFather on Telegram.
-func NewBotApiWithDebug(token string) (*BotAPI, error) {
-	return CreateNewBotApi(token, &http.Client{}, true)
+func NewBotAPIWithDebug(token string) (*BotAPI, error) {
+	return CreateNewBotAPI(token, &http.Client{}, true)
 }
 
-// NewBotAPIWithClient creates a new BotAPI instance
+// CreateNewBotAPI creates a new BotAPI instance
 // and allows you to pass all additional customization that you might need.
 //
 // It requires a token, provided by @BotFather on Telegram.
-func CreateNewBotApi(token string, client *http.Client, debug bool) (*BotAPI, error) {
+func CreateNewBotAPI(token string, client *http.Client, debug bool) (*BotAPI, error) {
 	bot := &BotAPI{
 		Token:  token,
 		Client: client,

--- a/passport.go
+++ b/passport.go
@@ -307,7 +307,7 @@ type (
 		MiddleNameNative     string `json:"middle_name_native"`
 	}
 
-	// IdDocumentData https://core.telegram.org/passport#iddocumentdata
+	// IDDocumentData https://core.telegram.org/passport#iddocumentdata
 	IDDocumentData struct {
 		DocumentNumber string `json:"document_no"`
 		ExpiryDate     string `json:"expiry_date"`


### PR DESCRIPTION
User are now able to create a bot with debug enabled by default.

The debug part is use full  when `NewBotAPI()` is failing with the message 

```
http.2.0bttrvjk5f4e@linuxkit-025000000001    | 2018/11/12 12:15:38 created msg
http.2.0bttrvjk5f4e@linuxkit-025000000001    | 2018/11/12 12:15:38 getting bot
http.2.0bttrvjk5f4e@linuxkit-025000000001    | 2018/11/12 12:15:38 error is about to happen
http.2.0bttrvjk5f4e@linuxkit-025000000001    | 2018/11/12 12:15:38 Not Found (this one 🤷🏾‍♂️)
```

By being able to enale debug when creating the bot user are able to debug the following code:

```
		b, err := tgbotapi.NewBotAPI(os.Getenv("TELEGRAM_BOT_TOKEN"))

		if err != nil {
			log.Print("error is about to happen")
			log.Fatal(err)
		}
```