### PR TITLE
fix add sticker to stickerset uploads by url and fileId

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -1417,7 +1417,9 @@ func (config AddStickerConfig) getFile() interface{} {
 }
 
 func (config AddStickerConfig) useExistingFile() bool {
-	return false
+	_, ok := config.PNGSticker.(string)
+
+	return ok
 }
 
 // SetStickerPositionConfig allows you to change the position of a sticker in a set.

--- a/configs.go
+++ b/configs.go
@@ -1327,7 +1327,9 @@ func (config UploadStickerConfig) getFile() interface{} {
 }
 
 func (config UploadStickerConfig) useExistingFile() bool {
-	return false
+	_, ok := config.PNGSticker.(string)
+
+	return ok
 }
 
 // NewStickerSetConfig allows creating a new sticker set.


### PR DESCRIPTION
Fixed sticker uploads by URL and fileId.
Now it the same as in `createNewSticker`