### PR TITLE
Remove bot method StopReceivingUpdates()

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -543,7 +543,7 @@ func ExampleNewBotAPI() {
 	time.Sleep(time.Millisecond * 500)
 	updates.Clear()
 
-	for update := range updates {
+	for update := range updates.Channel() {
 		if update.Message == nil {
 			continue
 		}
@@ -585,7 +585,7 @@ func ExampleNewWebhook() {
 	updates := bot.ListenForWebhook("/" + bot.Token)
 	go http.ListenAndServeTLS("0.0.0.0:8443", "cert.pem", "key.pem", nil)
 
-	for update := range updates {
+	for update := range updates.Channel() {
 		log.Printf("%+v\n", update)
 	}
 }
@@ -603,7 +603,7 @@ func ExampleInlineConfig() {
 
 	updates := bot.GetUpdatesChan(u)
 
-	for update := range updates {
+	for update := range updates.Channel() {
 		if update.InlineQuery == nil { // if no inline query, ignore it
 			continue
 		}

--- a/types.go
+++ b/types.go
@@ -39,13 +39,28 @@ type Update struct {
 	PreCheckoutQuery   *PreCheckoutQuery   `json:"pre_checkout_query"`
 }
 
-// UpdatesChannel is the channel for getting updates.
-type UpdatesChannel <-chan Update
+// UpdatesChannel is the struct that holds a channel for getting updates.
+type UpdatesChannel struct {
+	channel chan Update
+	done    chan struct{}
+}
+
+// Return Update channel
+func (updatesCh UpdatesChannel) Channel() <-chan Update {
+	return updatesCh.channel
+}
+
+// Stop channel feeding by goroutine or http handlers.
+//
+// It may not feed the update channel with all fetched/received Updates.
+func (updatesCh UpdatesChannel) Shutdown() {
+	updatesCh.done <- struct{}{}
+}
 
 // Clear discards all unprocessed incoming updates.
-func (ch UpdatesChannel) Clear() {
-	for len(ch) != 0 {
-		<-ch
+func (updatesCh UpdatesChannel) Clear() {
+	for len(updatesCh.channel) != 0 {
+		<-updatesCh.channel
 	}
 }
 


### PR DESCRIPTION
The StopReceivingUpdates() was used to stop a goroutine created at
GetUpdatesChannel().

If StopReceivingUpdates() were called twice or if GetUpdatesChannel()
were called after a StopReceivingUpdates() the bot behavior would be
incorrect due to 'shutdownChannel' close.

This commit removes StopReceivingUpdates() and modifies UpdatesChannel
struct to have a Shutdown() method which can stop both the associated
goroutine and http handler to feed the updates channel.

Signed-off-by: Vinicius Tinti <viniciustinti@gmail.com>