### PR TITLE
added PinnedMessage in Chat struct

### DIFF
--- a/types.go
+++ b/types.go
@@ -100,6 +100,7 @@ type Chat struct {
 	Photo               *ChatPhoto `json:"photo"`
 	Description         string     `json:"description,omitempty"` // optional
 	InviteLink          string     `json:"invite_link,omitempty"` // optional
+	PinnedMessage       *Message   `json:"pinned_message"`        // optional
 }
 
 // IsPrivate returns if the Chat is a private conversation.


### PR DESCRIPTION
Since BotAPI 3.3:
getChat now also returns pinned messages in supergroups, if present. Added the new field pinned_message to the Chat object.