### PR TITLE
closes #246

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -438,7 +438,7 @@ func (bot *BotAPI) GetUpdates(config UpdateConfig) ([]Update, error) {
 
 // RemoveWebhook unsets the webhook.
 func (bot *BotAPI) RemoveWebhook() (APIResponse, error) {
-	return bot.MakeRequest("setWebhook", url.Values{})
+	return bot.MakeRequest("deleteWebhook", url.Values{})
 }
 
 // SetWebhook sets a webhook.


### PR DESCRIPTION
Implements `deleteWebhook` Telegram API method instead of setting new with empty values