### PR TITLE
Change type of field ReplyMarkup for type BaseEdit to interface{}

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -160,7 +160,7 @@ type BaseEdit struct {
 	ChannelUsername string
 	MessageID       int
 	InlineMessageID string
-	ReplyMarkup     *InlineKeyboardMarkup
+	ReplyMarkup     interface{}
 }
 
 func (edit BaseEdit) values() (url.Values, error) {


### PR DESCRIPTION
The change provides editing reply markup if it has type ReplyKeyboardMarkup