### PR TITLE
Return pointer to error.

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -92,7 +92,7 @@ func (bot *BotAPI) MakeRequest(endpoint string, params url.Values) (APIResponse,
 		if apiResp.Parameters != nil {
 			parameters = *apiResp.Parameters
 		}
-		return apiResp, Error{Code: apiResp.ErrorCode, Message: apiResp.Description, ResponseParameters: parameters}
+		return apiResp, &Error{Code: apiResp.ErrorCode, Message: apiResp.Description, ResponseParameters: parameters}
 	}
 
 	return apiResp, nil


### PR DESCRIPTION
It seems to me, that it's more correct to return pointer to an error instead the copy of an Error's struct itself.

There are many examples in Go blog where we can see, that error is always returned as a pointer. So you can check if it is a special type of error or you can cast it to more specific.
[This article](https://blog.golang.org/go1.13-errors) can show this problem in details.