### PR TITLE
add ability to respond to inline queries with stickers

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -533,6 +533,16 @@ func NewInlineQueryResultCachedVideo(id, videoID, title string) InlineQueryResul
 	}
 }
 
+// NewInlineQueryResultCachedSticker create a new inline query with cached sticker.
+func NewInlineQueryResultCachedSticker(id, stickerID, title string) InlineQueryResultCachedSticker {
+	return InlineQueryResultCachedSticker{
+		Type:      "sticker",
+		ID:        id,
+		StickerID: stickerID,
+		Title:     title,
+	}
+}
+
 // NewInlineQueryResultAudio creates a new inline query audio.
 func NewInlineQueryResultAudio(id, url, title string) InlineQueryResultAudio {
 	return InlineQueryResultAudio{
@@ -622,7 +632,7 @@ func NewEditMessageCaption(chatID int64, messageID int, caption string) EditMess
 			ChatID:    chatID,
 			MessageID: messageID,
 		},
-		Caption:   caption,
+		Caption: caption,
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -736,6 +736,17 @@ type InlineQueryResultCachedVideo struct {
 	InputMessageContent interface{}           `json:"input_message_content,omitempty"`
 }
 
+// InlineQueryResultCachedSticker is an inline query response with cached sticker.
+type InlineQueryResultCachedSticker struct {
+	Type                string                `json:"type"`            // required
+	ID                  string                `json:"id"`              // required
+	StickerID           string                `json:"sticker_file_id"` // required
+	Title               string                `json:"title"`           // required
+	ParseMode           string                `json:"parse_mode"`
+	ReplyMarkup         *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+	InputMessageContent interface{}           `json:"input_message_content,omitempty"`
+}
+
 // InlineQueryResultAudio is an inline query response audio.
 type InlineQueryResultAudio struct {
 	Type                string                `json:"type"`      // required


### PR DESCRIPTION
Adds NewInlineQueryResultCachedSticker() and InlineQueryResultCachedSticker which are similar to to the other inline query responses, I guess this one was just missing for some reason. 