### PR TITLE
Add `is_animated` field to Sticker struct

### DIFF
--- a/types.go
+++ b/types.go
@@ -338,13 +338,14 @@ type Document struct {
 
 // Sticker contains information about a sticker.
 type Sticker struct {
-	FileID    string     `json:"file_id"`
-	Width     int        `json:"width"`
-	Height    int        `json:"height"`
-	Thumbnail *PhotoSize `json:"thumb"`     // optional
-	Emoji     string     `json:"emoji"`     // optional
-	FileSize  int        `json:"file_size"` // optional
-	SetName   string     `json:"set_name"`  // optional
+	FileID     string     `json:"file_id"`
+	Width      int        `json:"width"`
+	Height     int        `json:"height"`
+	Thumbnail  *PhotoSize `json:"thumb"`       // optional
+	Emoji      string     `json:"emoji"`       // optional
+	FileSize   int        `json:"file_size"`   // optional
+	SetName    string     `json:"set_name"`    // optional
+	IsAnimated bool       `json:"is_animated"` // optional
 }
 
 // ChatAnimation contains information about an animation.


### PR DESCRIPTION
[Bot API 4.4 version](https://core.telegram.org/bots/api#july-29-2019):

> Added support for animated stickers. New field is_animated in Sticker and StickerSet objects, animated stickers can now be used in sendSticker and InlineQueryResultCachedSticker.

This PR adds `is_animated` field to Sticker struct.