### PR TITLE
Include ResponseParameters in UploadFile error

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -226,7 +226,11 @@ func (bot *BotAPI) UploadFile(endpoint string, params map[string]string, fieldna
 	}
 
 	if !apiResp.Ok {
-		return APIResponse{}, errors.New(apiResp.Description)
+		parameters := ResponseParameters{}
+		if apiResp.Parameters != nil {
+			parameters = *apiResp.Parameters
+		}
+		return apiResp, Error{Code: apiResp.ErrorCode, Message: apiResp.Description, ResponseParameters: parameters}
 	}
 
 	return apiResp, nil
@@ -740,9 +744,9 @@ func (bot *BotAPI) UnbanChatMember(config ChatMemberConfig) (APIResponse, error)
 }
 
 // RestrictChatMember to restrict a user in a supergroup. The bot must be an
-//administrator in the supergroup for this to work and must have the
-//appropriate admin rights. Pass True for all boolean parameters to lift
-//restrictions from a user. Returns True on success.
+// administrator in the supergroup for this to work and must have the
+// appropriate admin rights. Pass True for all boolean parameters to lift
+// restrictions from a user. Returns True on success.
 func (bot *BotAPI) RestrictChatMember(config RestrictChatMemberConfig) (APIResponse, error) {
 	v := url.Values{}
 


### PR DESCRIPTION
In `*BotAPI.MakeRequest`, ResponseParameters is populated in the error when present:

https://github.com/go-telegram-bot-api/telegram-bot-api/blob/aa124ef1e84ecc14654ad242f3cf3bd2b0d5956c/bot.go#L90-L96

This is not being done in `*BotAPI.UploadFile`:

https://github.com/go-telegram-bot-api/telegram-bot-api/blob/aa124ef1e84ecc14654ad242f3cf3bd2b0d5956c/bot.go#L228-L230

This commit makes `*BotAPI.UploadFile behave similarly`.