### PR TITLE
Add "file_unique_id" to ChatAnimation, fix go mod name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-telegram-bot-api/telegram-bot-api/v5
+module github.com/go-telegram-bot-api/telegram-bot-api
 
 require github.com/technoweenie/multipartstreamer v1.0.1
 

--- a/types.go
+++ b/types.go
@@ -353,14 +353,15 @@ type MaskPosition struct {
 
 // ChatAnimation contains information about an animation.
 type ChatAnimation struct {
-	FileID    string     `json:"file_id"`
-	Width     int        `json:"width"`
-	Height    int        `json:"height"`
-	Duration  int        `json:"duration"`
-	Thumbnail *PhotoSize `json:"thumb"`     // optional
-	FileName  string     `json:"file_name"` // optional
-	MimeType  string     `json:"mime_type"` // optional
-	FileSize  int        `json:"file_size"` // optional
+	FileID       string     `json:"file_id"`
+	FileUniqueID string     `json:"file_unique_id"`
+	Width        int        `json:"width"`
+	Height       int        `json:"height"`
+	Duration     int        `json:"duration"`
+	Thumbnail    *PhotoSize `json:"thumb"`     // optional
+	FileName     string     `json:"file_name"` // optional
+	MimeType     string     `json:"mime_type"` // optional
+	FileSize     int        `json:"file_size"` // optional
 }
 
 // Video contains information about a video.


### PR DESCRIPTION
Add `FileUniqueID` to `ChatAnimation` (ref. https://core.telegram.org/bots/api#animation)
Fix go module name