### PR TITLE
Close updates chan on stop

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -495,6 +495,7 @@ func (bot *BotAPI) GetUpdatesChan(config UpdateConfig) (UpdatesChannel, error) {
 		for {
 			select {
 			case <-bot.shutdownChannel:
+				close(ch)
 				return
 			default:
 			}


### PR DESCRIPTION
Close the updates channel on bot shutdown so the functions reading from this channel can return