### PR TITLE
Fix nil pointer dereference in bot_test.go

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -468,16 +468,21 @@ func TestSetWebhookWithCert(t *testing.T) {
 	bot.RemoveWebhook()
 
 	wh := tgbotapi.NewWebhookWithCert("https://example.com/tgbotapi-test/"+bot.Token, "tests/cert.pem")
-	_, err := bot.SetWebhook(wh)
-	if err != nil {
-		t.Error(err)
-		t.Fail()
+	if wh.URL == nil {
+		t.Error("URL Parse Error: Invalid port after host")
+	} else {
+		_, err := bot.SetWebhook(wh)
+		if err != nil {
+			t.Error(err)
+			t.Fail()
+		}
+
+		_, err = bot.GetWebhookInfo()
+		if err != nil {
+			t.Error(err)
+		}
+		bot.RemoveWebhook()
 	}
-	_, err = bot.GetWebhookInfo()
-	if err != nil {
-		t.Error(err)
-	}
-	bot.RemoveWebhook()
 }
 
 func TestSetWebhookWithoutCert(t *testing.T) {
@@ -486,21 +491,26 @@ func TestSetWebhookWithoutCert(t *testing.T) {
 	time.Sleep(time.Second * 2)
 
 	bot.RemoveWebhook()
-
 	wh := tgbotapi.NewWebhook("https://example.com/tgbotapi-test/" + bot.Token)
-	_, err := bot.SetWebhook(wh)
-	if err != nil {
-		t.Error(err)
+	if wh.URL == nil {
+		t.Error("URL Parse Error: Invalid port after host")
 		t.Fail()
+	} else {
+		_, err := bot.SetWebhook(wh)
+		if err != nil {
+			t.Error(err)
+			t.Fail()
+		}
+
+		info, err := bot.GetWebhookInfo()
+		if err != nil {
+			t.Error(err)
+		}
+		if info.LastErrorDate != 0 {
+			t.Errorf("[Telegram callback failed]%s", info.LastErrorMessage)
+		}
+		bot.RemoveWebhook()
 	}
-	info, err := bot.GetWebhookInfo()
-	if err != nil {
-		t.Error(err)
-	}
-	if info.LastErrorDate != 0 {
-		t.Errorf("[Telegram callback failed]%s", info.LastErrorMessage)
-	}
-	bot.RemoveWebhook()
 }
 
 func TestUpdatesChan(t *testing.T) {

--- a/bot_test.go
+++ b/bot_test.go
@@ -469,7 +469,7 @@ func TestSetWebhookWithCert(t *testing.T) {
 
 	wh := tgbotapi.NewWebhookWithCert("https://example.com/tgbotapi-test/"+bot.Token, "tests/cert.pem")
 	if wh.URL == nil {
-		t.Error("URL Parse Error: Invalid port after host")
+		t.Error("URL Parse Error")
 	} else {
 		_, err := bot.SetWebhook(wh)
 		if err != nil {
@@ -493,8 +493,7 @@ func TestSetWebhookWithoutCert(t *testing.T) {
 	bot.RemoveWebhook()
 	wh := tgbotapi.NewWebhook("https://example.com/tgbotapi-test/" + bot.Token)
 	if wh.URL == nil {
-		t.Error("URL Parse Error: Invalid port after host")
-		t.Fail()
+		t.Error("URL Parse Error")
 	} else {
 		_, err := bot.SetWebhook(wh)
 		if err != nil {

--- a/helpers.go
+++ b/helpers.go
@@ -393,7 +393,10 @@ func NewUpdate(offset int) UpdateConfig {
 //
 // link is the url parsable link you wish to get the updates.
 func NewWebhook(link string) WebhookConfig {
-	u, _ := url.Parse(link)
+	u, err := url.Parse(link)
+	if err != nil {
+		return WebhookConfig{}
+	}
 
 	return WebhookConfig{
 		URL: u,
@@ -405,7 +408,10 @@ func NewWebhook(link string) WebhookConfig {
 // link is the url you wish to get webhooks,
 // file contains a string to a file, FileReader, or FileBytes.
 func NewWebhookWithCert(link string, file interface{}) WebhookConfig {
-	u, _ := url.Parse(link)
+	u, err := url.Parse(link)
+	if err != nil {
+		return WebhookConfig{}
+	}
 
 	return WebhookConfig{
 		URL:         u,


### PR DESCRIPTION
Fixed nil pointer dereference in bot_test.go, which is described in [this issue](https://github.com/go-telegram-bot-api/telegram-bot-api/issues/311)