### PR TITLE
Add update type selection

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -425,10 +425,15 @@ func (bot *BotAPI) GetFile(config FileConfig) (File, error) {
 // GetUpdates fetches updates.
 // If a WebHook is set, this will not return any data!
 //
-// Offset, Limit, and Timeout are optional.
+// Offset, Limit, Timeout and AllowedUpdates are optional.
 // To avoid stale items, set Offset to one higher than the previous item.
 // Set Timeout to a large number to reduce requests so you can get updates
 // instantly instead of having to wait between requests.
+//
+// Create the config object with NewUpdateWithFilter to be able to choose
+// which kind of updates you want.
+// You may get a short sequence of unfiltered updates becase the server
+// doesn't discard updates queued before setting the filter.
 func (bot *BotAPI) GetUpdates(config UpdateConfig) ([]Update, error) {
 	v := url.Values{}
 	if config.Offset != 0 {
@@ -439,6 +444,9 @@ func (bot *BotAPI) GetUpdates(config UpdateConfig) ([]Update, error) {
 	}
 	if config.Timeout > 0 {
 		v.Add("timeout", strconv.Itoa(config.Timeout))
+	}
+	if allowed := config.allowedUpdates; len(allowed) > 0 {
+		v.Add("allowed_updates", allowed)
 	}
 
 	resp, err := bot.MakeRequest("getUpdates", v)

--- a/bot_test.go
+++ b/bot_test.go
@@ -1,6 +1,7 @@
 package tgbotapi_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -56,6 +57,63 @@ func TestGetUpdates(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 		t.Fail()
+	}
+
+	// Test filtering
+	filters := []struct {
+		Types []tgbotapi.UpdateType
+		Valid bool
+	}{
+		{Types: []tgbotapi.UpdateType{}, Valid: true},
+		{Types: []tgbotapi.UpdateType{tgbotapi.UpdateType_All}, Valid: true},
+		{Types: []tgbotapi.UpdateType{tgbotapi.UpdateType_Default}, Valid: true},
+		{Types: []tgbotapi.UpdateType{tgbotapi.UpdateType_Message}, Valid: true},
+		{Types: []tgbotapi.UpdateType{tgbotapi.UpdateType_EditedMessage}, Valid: true},
+		{Types: []tgbotapi.UpdateType{tgbotapi.UpdateType_ChannelPost}, Valid: true},
+		{Types: []tgbotapi.UpdateType{tgbotapi.UpdateType_EditedChannelPost}, Valid: true},
+		{Types: []tgbotapi.UpdateType{tgbotapi.UpdateType_InlineQuery}, Valid: true},
+		{Types: []tgbotapi.UpdateType{tgbotapi.UpdateType_ChosenInlineResult}, Valid: true},
+		{Types: []tgbotapi.UpdateType{tgbotapi.UpdateType_CallbackQuery}, Valid: true},
+		{Types: []tgbotapi.UpdateType{tgbotapi.UpdateType_ShippingQuery}, Valid: true},
+		{Types: []tgbotapi.UpdateType{tgbotapi.UpdateType_PreCheckoutQuery}, Valid: true},
+		{Types: []tgbotapi.UpdateType{tgbotapi.UpdateType_Poll}, Valid: true},
+		{Types: []tgbotapi.UpdateType{tgbotapi.UpdateType_PollAnswer}, Valid: true},
+		{Types: []tgbotapi.UpdateType{
+			tgbotapi.UpdateType_Message,
+			tgbotapi.UpdateType_EditedMessage,
+		}, Valid: true},
+		{Types: []tgbotapi.UpdateType{1111}, Valid: false},
+		{Types: []tgbotapi.UpdateType{
+			tgbotapi.UpdateType_All,
+			tgbotapi.UpdateType_EditedMessage,
+		}, Valid: false},
+		{Types: []tgbotapi.UpdateType{
+			tgbotapi.UpdateType_Default,
+			tgbotapi.UpdateType_EditedMessage,
+		}, Valid: false},
+	}
+
+	for i, f := range filters {
+		u, err := tgbotapi.NewUpdateWithFilter(0, f.Types...)
+		if !f.Valid {
+			if err == nil {
+				t.Error(fmt.Errorf("%d should err", i))
+				t.Fail()
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Error(err)
+			t.Fail()
+		}
+
+		_, err = bot.GetUpdates(u)
+
+		if err != nil {
+			t.Error(err)
+			t.Fail()
+		}
 	}
 }
 

--- a/configs.go
+++ b/configs.go
@@ -47,6 +47,25 @@ const (
 	ErrBadURL      = "bad or empty url"
 )
 
+// Constants for update types for server-side filtering
+const (
+	UpdateType_Default = iota
+	UpdateType_All
+	UpdateType_Message
+	UpdateType_EditedMessage
+	UpdateType_ChannelPost
+	UpdateType_EditedChannelPost
+	UpdateType_InlineQuery
+	UpdateType_ChosenInlineResult
+	UpdateType_CallbackQuery
+	UpdateType_ShippingQuery
+	UpdateType_PreCheckoutQuery
+	UpdateType_Poll
+	UpdateType_PollAnswer
+)
+
+type UpdateType int
+
 // Chattable is any config type that can be sent.
 type Chattable interface {
 	values() (url.Values, error)
@@ -949,9 +968,10 @@ type FileConfig struct {
 
 // UpdateConfig contains information about a GetUpdates request.
 type UpdateConfig struct {
-	Offset  int
-	Limit   int
-	Timeout int
+	Offset         int
+	Limit          int
+	Timeout        int
+	allowedUpdates string
 }
 
 // WebhookConfig contains information about a SetWebhook request.


### PR DESCRIPTION
The API provides a field in the update request to indicate only a given
set of update types is desired, which saves both bandwidth and probably
latency.
This is implemented by adding a new way to create the UpdateConfig, as
well as adding a field for it.
To ensure validity of such field, the new method returns an error when
invalid and the field itself is private.
This shouldn't break existing code.