### PR TITLE
Include Error code in ResponseParameters to be able check it on telegram-bot-api.Error

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -111,6 +111,7 @@ func (bot *BotAPI) MakeRequest(endpoint string, params url.Values) (APIResponse,
 		if apiResp.Parameters != nil {
 			parameters = *apiResp.Parameters
 		}
+		parameters.ErrorCode = apiResp.ErrorCode
 		return apiResp, Error{Code: apiResp.ErrorCode, Message: apiResp.Description, ResponseParameters: parameters}
 	}
 

--- a/types.go
+++ b/types.go
@@ -21,6 +21,7 @@ type APIResponse struct {
 
 // ResponseParameters are various errors that can be returned in APIResponse.
 type ResponseParameters struct {
+	ErrorCode            int   `json:"-"`
 	MigrateToChatID int64 `json:"migrate_to_chat_id"` // optional
 	RetryAfter      int   `json:"retry_after"`        // optional
 }


### PR DESCRIPTION
```
m, err := api.Send(msg)
if terr, ok := err.(tgbotapi.Error); ok {
			logging.Default.Errorf("Bot send error %v %v", terr,m)
			if terr.RetryAfter > 0 {
				delaySec = terr.RetryAfter
			}
		}
```
This code snipper from master branch cant detect the bot is blocked by user no other means than check Message string and analyse it for Forbidden keyword. I think it is not very good idea and to extend the whole picture an error should inclide the origin http response code as well. So i include it on ResponseParameter structure as a simpliest workaround