### PR TITLE
Handle error in NewWebhook and NewWebhookWithCert

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -479,8 +479,13 @@ func TestSetWebhookWithCert(t *testing.T) {
 
 	bot.Request(RemoveWebhookConfig{})
 
-	wh := NewWebhookWithCert("https://example.com/tgbotapi-test/"+bot.Token, "tests/cert.pem")
-	_, err := bot.Request(wh)
+	wh, err := NewWebhookWithCert("https://example.com/tgbotapi-test/"+bot.Token, "tests/cert.pem")
+
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = bot.Request(wh)
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -501,8 +506,14 @@ func TestSetWebhookWithoutCert(t *testing.T) {
 
 	bot.Request(RemoveWebhookConfig{})
 
-	wh := NewWebhook("https://example.com/tgbotapi-test/" + bot.Token)
-	_, err := bot.Request(wh)
+	wh, err := NewWebhook("https://example.com/tgbotapi-test/" + bot.Token)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = bot.Request(wh)
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -589,7 +600,14 @@ func ExampleNewWebhook() {
 
 	log.Printf("Authorized on account %s", bot.Self.UserName)
 
-	_, err = bot.Request(NewWebhookWithCert("https://www.google.com:8443/"+bot.Token, "cert.pem"))
+	wh, err := NewWebhookWithCert("https://www.google.com:8443/"+bot.Token, "cert.pem")
+
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = bot.Request(wh)
+
 	if err != nil {
 		panic(err)
 	}
@@ -622,7 +640,13 @@ func ExampleWebhookHandler() {
 
 	log.Printf("Authorized on account %s", bot.Self.UserName)
 
-	_, err = bot.Request(NewWebhookWithCert("https://www.google.com:8443/"+bot.Token, "cert.pem"))
+	wh, err := NewWebhookWithCert("https://www.google.com:8443/"+bot.Token, "cert.pem")
+
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = bot.Request(wh)
 	if err != nil {
 		panic(err)
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -441,25 +441,33 @@ func NewUpdate(offset int) UpdateConfig {
 // NewWebhook creates a new webhook.
 //
 // link is the url parsable link you wish to get the updates.
-func NewWebhook(link string) WebhookConfig {
-	u, _ := url.Parse(link)
+func NewWebhook(link string) (WebhookConfig, error) {
+	u, err := url.Parse(link)
+
+	if err != nil {
+		return WebhookConfig{}, err
+	}
 
 	return WebhookConfig{
 		URL: u,
-	}
+	}, nil
 }
 
 // NewWebhookWithCert creates a new webhook with a certificate.
 //
 // link is the url you wish to get webhooks,
 // file contains a string to a file, FileReader, or FileBytes.
-func NewWebhookWithCert(link string, file interface{}) WebhookConfig {
-	u, _ := url.Parse(link)
+func NewWebhookWithCert(link string, file interface{}) (WebhookConfig, error) {
+	u, err := url.Parse(link)
+
+	if err != nil {
+		return WebhookConfig{}, err
+	}
 
 	return WebhookConfig{
 		URL:         u,
 		Certificate: file,
-	}
+	}, nil
 }
 
 // NewInlineQueryResultArticle creates a new inline query article.

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -4,6 +4,31 @@ import (
 	"testing"
 )
 
+func TestNewWebhook(t *testing.T) {
+	result, err := NewWebhook("https://example.com/token")
+
+	if err != nil ||
+		result.URL.String() != "https://example.com/token" ||
+		result.Certificate != interface{}(nil) ||
+		result.MaxConnections != 0 ||
+		len(result.AllowedUpdates) != 0 {
+		t.Fail()
+	}
+}
+
+func TestNewWebhookWithCert(t *testing.T) {
+	exampleFile := File{FileID: "123"}
+	result, err := NewWebhookWithCert("https://example.com/token", exampleFile)
+
+	if err != nil ||
+		result.URL.String() != "https://example.com/token" ||
+		result.Certificate != exampleFile ||
+		result.MaxConnections != 0 ||
+		len(result.AllowedUpdates) != 0 {
+		t.Fail()
+	}
+}
+
 func TestNewInlineQueryResultArticle(t *testing.T) {
 	result := NewInlineQueryResultArticle("id", "title", "message")
 


### PR DESCRIPTION
The PR handles and returns error in NewWebhook and NewWebhookWithCert functions. I added tests for both and adjusted tests that depend on them.

Fixes #311