### PR TITLE
Add 3 new fields to User object

### DIFF
--- a/types.go
+++ b/types.go
@@ -51,12 +51,15 @@ func (ch UpdatesChannel) Clear() {
 
 // User is a user on Telegram.
 type User struct {
-	ID           int    `json:"id"`
-	FirstName    string `json:"first_name"`
-	LastName     string `json:"last_name"`     // optional
-	UserName     string `json:"username"`      // optional
-	LanguageCode string `json:"language_code"` // optional
-	IsBot        bool   `json:"is_bot"`        // optional
+	ID                      int    `json:"id"`
+	FirstName               string `json:"first_name"`
+	LastName                string `json:"last_name"`                   // optional
+	UserName                string `json:"username"`                    // optional
+	LanguageCode            string `json:"language_code"`               // optional
+	IsBot                   bool   `json:"is_bot"`                      // optional
+	CanJoinGroups           bool   `json:"can_join_groups"`             // optional. Returned only in getMe
+	CanReadAllGroupMessages bool   `json:"can_read_all_group_messages"` // optional. Returned only in getMe
+	SupportsInlineQueries   bool   `json:"supports_inline_queries"`     // optional. Returned only in getMe
 }
 
 // String displays a simple text version of a user.


### PR DESCRIPTION
Adding 3 new fields to `User` object as per docs here: https://core.telegram.org/bots/api#user

Field | Type | Comment
-- | -- | --
can_join_groups | Boolean | Optional. True, if the bot can be invited to groups. Returned only in getMe.
can_read_all_group_messages | Boolean | Optional. True, if privacy mode is disabled for the bot. Returned only in getMe.
supports_inline_queries | Boolean | Optional. True, if the bot supports inline queries. Returned only in getMe.

