### PR TITLE
Update error handling in NewWebhook(WithCert)

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -1013,6 +1013,15 @@ type WebhookConfig struct {
 	URL            *url.URL
 	Certificate    interface{}
 	MaxConnections int
+
+	// err is the error generated during the creation of the WebhookConfig
+	// use GetError to retrive
+	err error
+}
+
+// GetError returns the error inside WEbhookConfig, should be checked after creating
+func (info WebhookConfig) GetError() error {
+	return info.err
 }
 
 // FileBytes contains information about a set of bytes to upload

--- a/helpers.go
+++ b/helpers.go
@@ -417,10 +417,12 @@ func NewUpdate(offset int) UpdateConfig {
 //
 // link is the url parsable link you wish to get the updates.
 func NewWebhook(link string) WebhookConfig {
-	u, _ := url.Parse(link)
+	u, err := url.Parse(link)
+	// Cannot return error for compatibility reasons
 
 	return WebhookConfig{
 		URL: u,
+		err: err,
 	}
 }
 
@@ -429,11 +431,22 @@ func NewWebhook(link string) WebhookConfig {
 // link is the url you wish to get webhooks,
 // file contains a string to a file, FileReader, or FileBytes.
 func NewWebhookWithCert(link string, file interface{}) WebhookConfig {
-	u, _ := url.Parse(link)
+	u, err := url.Parse(link)
+
+	switch file.(type) {
+	case string:
+	case FileReader:
+	case FileBytes:
+		break
+
+	default:
+		panic("NewWebhookWithCert: file is not a valid type")
+	}
 
 	return WebhookConfig{
 		URL:         u,
 		Certificate: file,
+		err:         err,
 	}
 }
 


### PR DESCRIPTION
This pull request adds a way to check the error of NewWebhook(WithCert) without **breaking changes**.
Add `GetError` method to check if an error occurred,
`Error` was not to not implement error interface

Add **panic** when file is not a good type, while this do not fixes the error at compile time a panic at run-time would be better than nothing.

Fixes #311 