### PR TITLE
Escape Telegram formatting symbols

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -1072,7 +1072,7 @@ func (bot *BotAPI) SetMyCommands(commands []BotCommand) error {
 //
 // parseMode is the text formatting mode (ModeMarkdown, ModeMarkdownV2 or ModeHTML)
 // text is the input string that will be escaped
-func (*BotAPI) EscapeText(parseMode string, text string) string {
+func EscapeText(parseMode string, text string) string {
 	var replacer *strings.Replacer
 
 	if parseMode == ModeHTML {

--- a/bot.go
+++ b/bot.go
@@ -1065,3 +1065,30 @@ func (bot *BotAPI) SetMyCommands(commands []BotCommand) error {
 	}
 	return nil
 }
+
+// EscapeText takes an input text and escape Telegram markup symbols.
+// In this way we can send a text without being afraid of having to escape the characters manually.
+// Note that you don't have to include the formatting style in the input text, or it will be escaped too.
+//
+// parseMode is the text formatting mode (ModeMarkdown, ModeMarkdownV2 or ModeHTML)
+// text is the input string that will be escaped
+func (*BotAPI) EscapeText(parseMode string, text string) string {
+	var replacer *strings.Replacer
+
+	if parseMode == ModeHTML {
+		replacer = strings.NewReplacer("<", "&lt;", ">", "&gt;", "&", "&amp;")
+	} else if parseMode == ModeMarkdown {
+		replacer = strings.NewReplacer("_", "\\_", "*", "\\*", "`", "\\`", "[", "\\[")
+	} else if parseMode == ModeMarkdownV2 {
+		replacer = strings.NewReplacer(
+			"_", "\\_", "*", "\\*", "[", "\\[", "]", "\\]", "(",
+			"\\(", ")", "\\)", "~", "\\~", "`", "\\`", ">", "\\>",
+			"#", "\\#", "+", "\\+", "-", "\\-", "=", "\\=", "|",
+			"\\|", "{", "\\{", "}", "\\}", ".", "\\.", "!", "\\!",
+		)
+	} else {
+		return ""
+	}
+
+	return replacer.Replace(text)
+}

--- a/bot.go
+++ b/bot.go
@@ -1069,6 +1069,7 @@ func (bot *BotAPI) SetMyCommands(commands []BotCommand) error {
 // EscapeText takes an input text and escape Telegram markup symbols.
 // In this way we can send a text without being afraid of having to escape the characters manually.
 // Note that you don't have to include the formatting style in the input text, or it will be escaped too.
+// If there is an error, an empty string will be returned.
 //
 // parseMode is the text formatting mode (ModeMarkdown, ModeMarkdownV2 or ModeHTML)
 // text is the input string that will be escaped


### PR DESCRIPTION
I have created this function that, according to Telegram parse mode, escape the formatting special symbols.
For example, if you have to reply with the user's name, in a MarkdownV2 message, with this function you are sure that the special characters that may be contained in the name are escaped, and the message will be shipped correctly.