### PR TITLE
Add missing attributes to Audio and Video types

### DIFF
--- a/types.go
+++ b/types.go
@@ -606,6 +606,14 @@ type Audio struct {
 	//
 	// optional
 	Title string `json:"title"`
+	// Thumbnail audio thumbnail
+	//
+	// optional
+	Thumbnail *PhotoSize `json:"thumb"`
+	// FileName original audio filename as defined by sender
+	//
+	// optional
+	FileName string `json:"file_name"`
 	// MimeType of the file as defined by sender
 	//
 	// optional
@@ -728,6 +736,10 @@ type Video struct {
 	//
 	// optional
 	Thumbnail *PhotoSize `json:"thumb"`
+	// FileName original video filename as defined by sender
+	//
+	// optional
+	FileName string `json:"file_name"`
 	// MimeType of a file as defined by sender
 	//
 	// optional


### PR DESCRIPTION
from [here](https://core.telegram.org/bots/api)
> ### November 4, 2020
> Introducing **Bot API 5.0**
>
> #### Working with Files
> * Added the field file_name to the classes [Audio](https://core.telegram.org/bots/api#audio) and [Video](https://core.telegram.org/bots/api#video), containing the name of the original file.