### PR TITLE
Add SIV to import paths to support modules

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-telegram-bot-api/telegram-bot-api
+module github.com/go-telegram-bot-api/telegram-bot-api/v5
 
 go 1.12
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -3,7 +3,7 @@ package tgbotapi_test
 import (
 	"testing"
 
-	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
 
 func TestNewInlineQueryResultArticle(t *testing.T) {

--- a/types_test.go
+++ b/types_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
 
 func TestUserStringWith(t *testing.T) {


### PR DESCRIPTION
Import paths need to use Semantic Import Versioning or they won't work. If you look at the package site, you'll see you're missing all versions after you added `go.mod`. It also lists v1.0.0 as the newest version.

https://pkg.go.dev/github.com/go-telegram-bot-api/telegram-bot-api?tab=versions

It's also impossible to `go get` the package. 

```
go get github.com/go-telegram-bot-api/telegram-bot-api/v5@v5.0.1: github.com/go-telegram-bot-api/telegram-bot-api@v5.0.1: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v5
```

fixes: #382