### PR TITLE
Adding caption option to multiple upload / share handlers

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -100,7 +100,7 @@ func TestSendWithMessageForward(t *testing.T) {
 func TestSendWithNewPhoto(t *testing.T) {
 	bot, _ := getBot(t)
 
-	msg := tgbotapi.NewPhotoUpload(ChatID, "tests/image.jpg")
+	msg := tgbotapi.NewPhotoUpload(ChatID, "tests/image.jpg", "")
 	msg.Caption = "Test"
 	_, err := bot.Send(msg)
 
@@ -116,7 +116,7 @@ func TestSendWithNewPhotoWithFileBytes(t *testing.T) {
 	data, _ := ioutil.ReadFile("tests/image.jpg")
 	b := tgbotapi.FileBytes{Name: "image.jpg", Bytes: data}
 
-	msg := tgbotapi.NewPhotoUpload(ChatID, b)
+	msg := tgbotapi.NewPhotoUpload(ChatID, b, "")
 	msg.Caption = "Test"
 	_, err := bot.Send(msg)
 
@@ -132,7 +132,7 @@ func TestSendWithNewPhotoWithFileReader(t *testing.T) {
 	f, _ := os.Open("tests/image.jpg")
 	reader := tgbotapi.FileReader{Name: "image.jpg", Reader: f, Size: -1}
 
-	msg := tgbotapi.NewPhotoUpload(ChatID, reader)
+	msg := tgbotapi.NewPhotoUpload(ChatID, reader, "")
 	msg.Caption = "Test"
 	_, err := bot.Send(msg)
 
@@ -145,7 +145,7 @@ func TestSendWithNewPhotoWithFileReader(t *testing.T) {
 func TestSendWithNewPhotoReply(t *testing.T) {
 	bot, _ := getBot(t)
 
-	msg := tgbotapi.NewPhotoUpload(ChatID, "tests/image.jpg")
+	msg := tgbotapi.NewPhotoUpload(ChatID, "tests/image.jpg", "")
 	msg.ReplyToMessageID = ReplyToMessageID
 
 	_, err := bot.Send(msg)
@@ -159,7 +159,7 @@ func TestSendWithNewPhotoReply(t *testing.T) {
 func TestSendWithExistingPhoto(t *testing.T) {
 	bot, _ := getBot(t)
 
-	msg := tgbotapi.NewPhotoShare(ChatID, ExistingPhotoFileID)
+	msg := tgbotapi.NewPhotoShare(ChatID, ExistingPhotoFileID, "")
 	msg.Caption = "Test"
 	_, err := bot.Send(msg)
 
@@ -172,7 +172,7 @@ func TestSendWithExistingPhoto(t *testing.T) {
 func TestSendWithNewDocument(t *testing.T) {
 	bot, _ := getBot(t)
 
-	msg := tgbotapi.NewDocumentUpload(ChatID, "tests/image.jpg")
+	msg := tgbotapi.NewDocumentUpload(ChatID, "tests/image.jpg", "")
 	_, err := bot.Send(msg)
 
 	if err != nil {
@@ -184,7 +184,7 @@ func TestSendWithNewDocument(t *testing.T) {
 func TestSendWithExistingDocument(t *testing.T) {
 	bot, _ := getBot(t)
 
-	msg := tgbotapi.NewDocumentShare(ChatID, ExistingDocumentFileID)
+	msg := tgbotapi.NewDocumentShare(ChatID, ExistingDocumentFileID, "")
 	_, err := bot.Send(msg)
 
 	if err != nil {
@@ -196,7 +196,7 @@ func TestSendWithExistingDocument(t *testing.T) {
 func TestSendWithNewAudio(t *testing.T) {
 	bot, _ := getBot(t)
 
-	msg := tgbotapi.NewAudioUpload(ChatID, "tests/audio.mp3")
+	msg := tgbotapi.NewAudioUpload(ChatID, "tests/audio.mp3", "")
 	msg.Title = "TEST"
 	msg.Duration = 10
 	msg.Performer = "TEST"
@@ -242,7 +242,7 @@ func TestSendWithNewVoice(t *testing.T) {
 func TestSendWithExistingVoice(t *testing.T) {
 	bot, _ := getBot(t)
 
-	msg := tgbotapi.NewVoiceShare(ChatID, ExistingVoiceFileID)
+	msg := tgbotapi.NewVoiceShare(ChatID, ExistingVoiceFileID, "")
 	msg.Duration = 10
 	_, err := bot.Send(msg)
 
@@ -288,7 +288,7 @@ func TestSendWithVenue(t *testing.T) {
 func TestSendWithNewVideo(t *testing.T) {
 	bot, _ := getBot(t)
 
-	msg := tgbotapi.NewVideoUpload(ChatID, "tests/video.mp4")
+	msg := tgbotapi.NewVideoUpload(ChatID, "tests/video.mp4", "")
 	msg.Duration = 10
 	msg.Caption = "TEST"
 

--- a/helpers.go
+++ b/helpers.go
@@ -82,13 +82,14 @@ func NewForward(chatID int64, fromChatID int64, messageID int) ForwardConfig {
 // FileReader, or FileBytes.
 //
 // Note that you must send animated GIFs as a document.
-func NewPhotoUpload(chatID int64, file interface{}) PhotoConfig {
+func NewPhotoUpload(chatID int64, file interface{}, caption string) PhotoConfig {
 	return PhotoConfig{
 		BaseFile: BaseFile{
 			BaseChat:    BaseChat{ChatID: chatID},
 			File:        file,
 			UseExisting: false,
 		},
+		Caption: caption,
 	}
 }
 
@@ -97,13 +98,14 @@ func NewPhotoUpload(chatID int64, file interface{}) PhotoConfig {
 //
 // chatID is where to send it, fileID is the ID of the file
 // already uploaded.
-func NewPhotoShare(chatID int64, fileID string) PhotoConfig {
+func NewPhotoShare(chatID int64, fileID string, caption string) PhotoConfig {
 	return PhotoConfig{
 		BaseFile: BaseFile{
 			BaseChat:    BaseChat{ChatID: chatID},
 			FileID:      fileID,
 			UseExisting: true,
 		},
+		Caption: caption,
 	}
 }
 
@@ -111,13 +113,14 @@ func NewPhotoShare(chatID int64, fileID string) PhotoConfig {
 //
 // chatID is where to send it, file is a string path to the file,
 // FileReader, or FileBytes.
-func NewAudioUpload(chatID int64, file interface{}) AudioConfig {
+func NewAudioUpload(chatID int64, file interface{}, caption string) AudioConfig {
 	return AudioConfig{
 		BaseFile: BaseFile{
 			BaseChat:    BaseChat{ChatID: chatID},
 			File:        file,
 			UseExisting: false,
 		},
+		Caption: caption,
 	}
 }
 
@@ -141,13 +144,14 @@ func NewAudioShare(chatID int64, fileID string) AudioConfig {
 //
 // chatID is where to send it, file is a string path to the file,
 // FileReader, or FileBytes.
-func NewDocumentUpload(chatID int64, file interface{}) DocumentConfig {
+func NewDocumentUpload(chatID int64, file interface{}, caption string) DocumentConfig {
 	return DocumentConfig{
 		BaseFile: BaseFile{
 			BaseChat:    BaseChat{ChatID: chatID},
 			File:        file,
 			UseExisting: false,
 		},
+		Caption: caption,
 	}
 }
 
@@ -157,13 +161,14 @@ func NewDocumentUpload(chatID int64, file interface{}) DocumentConfig {
 //
 // chatID is where to send it, fileID is the ID of the document
 // already uploaded.
-func NewDocumentShare(chatID int64, fileID string) DocumentConfig {
+func NewDocumentShare(chatID int64, fileID string, caption string) DocumentConfig {
 	return DocumentConfig{
 		BaseFile: BaseFile{
 			BaseChat:    BaseChat{ChatID: chatID},
 			FileID:      fileID,
 			UseExisting: true,
 		},
+		Caption: caption,
 	}
 }
 
@@ -201,13 +206,14 @@ func NewStickerShare(chatID int64, fileID string) StickerConfig {
 //
 // chatID is where to send it, file is a string path to the file,
 // FileReader, or FileBytes.
-func NewVideoUpload(chatID int64, file interface{}) VideoConfig {
+func NewVideoUpload(chatID int64, file interface{}, caption string) VideoConfig {
 	return VideoConfig{
 		BaseFile: BaseFile{
 			BaseChat:    BaseChat{ChatID: chatID},
 			File:        file,
 			UseExisting: false,
 		},
+		Caption: caption,
 	}
 }
 
@@ -230,13 +236,14 @@ func NewVideoShare(chatID int64, fileID string) VideoConfig {
 //
 // chatID is where to send it, file is a string path to the file,
 // FileReader, or FileBytes.
-func NewAnimationUpload(chatID int64, file interface{}) AnimationConfig {
+func NewAnimationUpload(chatID int64, file interface{}, caption string) AnimationConfig {
 	return AnimationConfig{
 		BaseFile: BaseFile{
 			BaseChat:    BaseChat{ChatID: chatID},
 			File:        file,
 			UseExisting: false,
 		},
+		Caption: caption,
 	}
 }
 
@@ -245,13 +252,14 @@ func NewAnimationUpload(chatID int64, file interface{}) AnimationConfig {
 //
 // chatID is where to send it, fileID is the ID of the animation
 // already uploaded.
-func NewAnimationShare(chatID int64, fileID string) AnimationConfig {
+func NewAnimationShare(chatID int64, fileID string, caption string) AnimationConfig {
 	return AnimationConfig{
 		BaseFile: BaseFile{
 			BaseChat:    BaseChat{ChatID: chatID},
 			FileID:      fileID,
 			UseExisting: true,
 		},
+		Caption: caption,
 	}
 }
 
@@ -305,13 +313,14 @@ func NewVoiceUpload(chatID int64, file interface{}) VoiceConfig {
 //
 // chatID is where to send it, fileID is the ID of the video
 // already uploaded.
-func NewVoiceShare(chatID int64, fileID string) VoiceConfig {
+func NewVoiceShare(chatID int64, fileID string, caption string) VoiceConfig {
 	return VoiceConfig{
 		BaseFile: BaseFile{
 			BaseChat:    BaseChat{ChatID: chatID},
 			FileID:      fileID,
 			UseExisting: true,
 		},
+		Caption: caption,
 	}
 }
 


### PR DESCRIPTION
As needed for some projects depended on telegram-bot-api we can expose the caption option in the handlers.