### PR TITLE
Add support switch to local server

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -1066,6 +1066,16 @@ func (bot *BotAPI) SetMyCommands(commands []BotCommand) error {
 	return nil
 }
 
+// LogOut log out from the cloud Bot API server before launching the bot locally
+func (bot *BotAPI) LogOut() error {
+	_, err := bot.MakeRequest("logOut", nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // EscapeText takes an input text and escape Telegram markup symbols.
 // In this way we can send a text without being afraid of having to escape the characters manually.
 // Note that you don't have to include the formatting style in the input text, or it will be escaped too.

--- a/configs.go
+++ b/configs.go
@@ -2,6 +2,7 @@ package tgbotapi
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/url"
 	"strconv"
@@ -18,9 +19,10 @@ func init() {
 	FileEndpoint = "https://api.telegram.org/file/bot%s/%s"
 }
 
-// ReplaceAPIEndpoint replace the API endpoint to switch to local server
-func ReplaceAPIEndpoint() {
-	APIEndpoint = "http://127.0.0.1:8081/bot%s/%s"
+// SwitchAPIEndpointToLocal switch the API endpoint to local bot api server
+// with customize port
+func SwitchAPIEndpointToLocal(port int) {
+	APIEndpoint = fmt.Sprintf("http://127.0.0.1:%d", port) + "/bot%s/%s"
 }
 
 // Constant values for ChatActions

--- a/configs.go
+++ b/configs.go
@@ -7,14 +7,21 @@ import (
 	"strconv"
 )
 
-// Telegram constants
-const (
-	// APIEndpoint is the endpoint for all API methods,
-	// with formatting for Sprintf.
+// APIEndpoint is the endpoint for all API methods,
+// with formatting for Sprintf.
+var APIEndpoint string
+// FileEndpoint is the endpoint for downloading a file from Telegram.
+var FileEndpoint string
+
+func init() {
 	APIEndpoint = "https://api.telegram.org/bot%s/%s"
-	// FileEndpoint is the endpoint for downloading a file from Telegram.
 	FileEndpoint = "https://api.telegram.org/file/bot%s/%s"
-)
+}
+
+// ReplaceAPIEndpoint replace the API endpoint to switch to local server
+func ReplaceAPIEndpoint() {
+	APIEndpoint = "http://127.0.0.1:8081/bot%s/%s"
+}
 
 // Constant values for ChatActions
 const (

--- a/configs.go
+++ b/configs.go
@@ -20,9 +20,10 @@ func init() {
 }
 
 // SwitchAPIEndpointToLocal switch the API endpoint to local bot api server
-// with customize port
-func SwitchAPIEndpointToLocal(port int) {
-	APIEndpoint = fmt.Sprintf("http://127.0.0.1:%d", port) + "/bot%s/%s"
+// with customize IP or domain, and port
+// local bot api server only support HTTP requests
+func SwitchAPIEndpointToLocal(host, port string) {
+	APIEndpoint = fmt.Sprintf("http://%s:%s", host, port) + "/bot%s/%s"
 }
 
 // Constant values for ChatActions


### PR DESCRIPTION
In order to use [Local Bot API Server Features](https://core.telegram.org/bots/api#using-a-local-bot-api-server), I add method `LogOut()` to log out from the cloud Bot API server, and function `SwitchAPIEndpointToLocal()` to switch `APIEndpoint` to local api server.
I currently switch to local api server to download files larger than 20 MB and it's functioning well.