### PR TITLE
Update go module for the last tag - v5

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-telegram-bot-api/telegram-bot-api
+module github.com/go-telegram-bot-api/telegram-bot-api/v5
 
 go 1.12
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -3,7 +3,7 @@ package tgbotapi_test
 import (
 	"testing"
 
-	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
 
 func TestNewInlineQueryResultArticle(t *testing.T) {

--- a/types_test.go
+++ b/types_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
 
 func TestUserStringWith(t *testing.T) {


### PR DESCRIPTION
Actualize go module for the last tag: v5.0.1
Issue: "v5.0.1 misses go mod version #407"
