### PR TITLE
GO VERSION: update to 1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/go-telegram-bot-api/telegram-bot-api
 
-go 1.12
+go 1.15
 
 require github.com/technoweenie/multipartstreamer v1.0.1


### PR DESCRIPTION
In current date (2021-02-13) last stable golang version: 1.15.
And for this reason - update go version in go.mod.