### PR TITLE
Change UserID to int64

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -672,7 +672,7 @@ func (config GameConfig) method() string {
 
 // SetGameScoreConfig allows you to update the game score in a chat.
 type SetGameScoreConfig struct {
-	UserID             int
+	UserID             int64
 	Score              int
 	Force              bool
 	DisableEditMessage bool
@@ -685,7 +685,7 @@ type SetGameScoreConfig struct {
 func (config SetGameScoreConfig) params() (Params, error) {
 	params := make(Params)
 
-	params.AddNonZero("user_id", config.UserID)
+	params.AddNonZero64("user_id", config.UserID)
 	params.AddNonZero("scrore", config.Score)
 	params.AddBool("disable_edit_message", config.DisableEditMessage)
 
@@ -705,8 +705,8 @@ func (config SetGameScoreConfig) method() string {
 
 // GetGameHighScoresConfig allows you to fetch the high scores for a game.
 type GetGameHighScoresConfig struct {
-	UserID          int
-	ChatID          int
+	UserID          int64
+	ChatID          int64
 	ChannelUsername string
 	MessageID       int
 	InlineMessageID string
@@ -715,7 +715,7 @@ type GetGameHighScoresConfig struct {
 func (config GetGameHighScoresConfig) params() (Params, error) {
 	params := make(Params)
 
-	params.AddNonZero("user_id", config.UserID)
+	params.AddNonZero64("user_id", config.UserID)
 
 	if config.InlineMessageID != "" {
 		params["inline_message_id"] = config.InlineMessageID
@@ -850,7 +850,7 @@ func (StopPollConfig) method() string {
 // UserProfilePhotosConfig contains information about a
 // GetUserProfilePhotos request.
 type UserProfilePhotosConfig struct {
-	UserID int
+	UserID int64
 	Offset int
 	Limit  int
 }
@@ -862,7 +862,7 @@ func (UserProfilePhotosConfig) method() string {
 func (config UserProfilePhotosConfig) params() (Params, error) {
 	params := make(Params)
 
-	params.AddNonZero("user_id", config.UserID)
+	params.AddNonZero64("user_id", config.UserID)
 	params.AddNonZero("offset", config.Offset)
 	params.AddNonZero("limit", config.Limit)
 
@@ -1041,7 +1041,7 @@ type ChatMemberConfig struct {
 	ChatID             int64
 	SuperGroupUsername string
 	ChannelUsername    string
-	UserID             int
+	UserID             int64
 }
 
 // UnbanChatMemberConfig allows you to unban a user.
@@ -1058,7 +1058,7 @@ func (config UnbanChatMemberConfig) params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername, config.ChannelUsername)
-	params.AddNonZero("user_id", config.UserID)
+	params.AddNonZero64("user_id", config.UserID)
 	params.AddBool("only_if_banned", config.OnlyIfBanned)
 
 	return params, nil
@@ -1079,7 +1079,7 @@ func (config KickChatMemberConfig) params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername)
-	params.AddNonZero("user_id", config.UserID)
+	params.AddNonZero64("user_id", config.UserID)
 	params.AddNonZero64("until_date", config.UntilDate)
 	params.AddBool("revoke_messages", config.RevokeMessages)
 
@@ -1101,7 +1101,7 @@ func (config RestrictChatMemberConfig) params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername, config.ChannelUsername)
-	params.AddNonZero("user_id", config.UserID)
+	params.AddNonZero64("user_id", config.UserID)
 
 	err := params.AddInterface("permissions", config.Permissions)
 	params.AddNonZero64("until_date", config.UntilDate)
@@ -1133,7 +1133,7 @@ func (config PromoteChatMemberConfig) params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername, config.ChannelUsername)
-	params.AddNonZero("user_id", config.UserID)
+	params.AddNonZero64("user_id", config.UserID)
 
 	params.AddBool("is_anonymous", config.IsAnonymous)
 	params.AddBool("can_manage_chat", config.CanManageChat)
@@ -1165,7 +1165,7 @@ func (config SetChatAdministratorCustomTitle) params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername, config.ChannelUsername)
-	params.AddNonZero("user_id", config.UserID)
+	params.AddNonZero64("user_id", config.UserID)
 	params.AddNonEmpty("custom_title", config.CustomTitle)
 
 	return params, nil
@@ -1345,14 +1345,14 @@ func (config LeaveChatConfig) params() (Params, error) {
 type ChatConfigWithUser struct {
 	ChatID             int64
 	SuperGroupUsername string
-	UserID             int
+	UserID             int64
 }
 
 func (config ChatConfigWithUser) params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername)
-	params.AddNonZero("user_id", config.UserID)
+	params.AddNonZero64("user_id", config.UserID)
 
 	return params, nil
 }
@@ -1828,7 +1828,7 @@ func (config DeleteStickerConfig) params() (Params, error) {
 // SetStickerSetThumbConfig allows you to set the thumbnail for a sticker set.
 type SetStickerSetThumbConfig struct {
 	Name   string
-	UserID int
+	UserID int64
 	Thumb  interface{}
 }
 
@@ -1840,7 +1840,7 @@ func (config SetStickerSetThumbConfig) params() (Params, error) {
 	params := make(Params)
 
 	params["name"] = config.Name
-	params.AddNonZero("user_id", config.UserID)
+	params.AddNonZero64("user_id", config.UserID)
 
 	if thumb, ok := config.Thumb.(string); ok {
 		params["thumb"] = thumb

--- a/helpers.go
+++ b/helpers.go
@@ -431,7 +431,7 @@ func NewChatAction(chatID int64, action string) ChatActionConfig {
 // NewUserProfilePhotos gets user profile photos.
 //
 // userID is the ID of the user you wish to get profile photos from.
-func NewUserProfilePhotos(userID int) UserProfilePhotosConfig {
+func NewUserProfilePhotos(userID int64) UserProfilePhotosConfig {
 	return UserProfilePhotosConfig{
 		UserID: userID,
 		Offset: 0,

--- a/types.go
+++ b/types.go
@@ -123,7 +123,7 @@ func (ch UpdatesChannel) Clear() {
 // User represents a Telegram user or bot.
 type User struct {
 	// ID is a unique identifier for this user or bot
-	ID int `json:"id"`
+	ID int64 `json:"id"`
 	// IsBot true, if this user is a bot
 	//
 	// optional
@@ -178,12 +178,6 @@ func (u *User) String() string {
 	}
 
 	return name
-}
-
-// GroupChat is a group chat.
-type GroupChat struct {
-	ID    int    `json:"id"`
-	Title string `json:"title"`
 }
 
 // Chat represents a chat.
@@ -922,7 +916,7 @@ type Contact struct {
 	// UserID contact's user identifier in Telegram
 	//
 	// optional
-	UserID int `json:"user_id,omitempty"`
+	UserID int64 `json:"user_id,omitempty"`
 	// VCard is additional data about the contact in the form of a vCard.
 	//
 	// optional


### PR DESCRIPTION
As per Telegram docs, user IDs will potentially contain up to 52 significant bits. 

> After one of the upcoming Bot API updates, some user identifiers will become bigger than `2^31 - 1` and it will be no longer possible to store them in a signed 32-bit integer type. User identifiers will have up to 52 significant bits, so a 64-bit integer or double-precision float type would still be safe for storing them. Please make sure that your code can correctly handle such user identifiers.