### PR TITLE
Updates for Bot API 5.3

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -667,9 +667,7 @@ func (bot *BotAPI) StopPoll(config StopPollConfig) (Poll, error) {
 }
 
 // GetMyCommands gets the currently registered commands.
-func (bot *BotAPI) GetMyCommands() ([]BotCommand, error) {
-	config := GetMyCommandsConfig{}
-
+func (bot *BotAPI) GetMyCommands(config GetMyCommandsConfig) ([]BotCommand, error) {
 	resp, err := bot.Request(config)
 	if err != nil {
 		return nil, err

--- a/bot.go
+++ b/bot.go
@@ -667,7 +667,12 @@ func (bot *BotAPI) StopPoll(config StopPollConfig) (Poll, error) {
 }
 
 // GetMyCommands gets the currently registered commands.
-func (bot *BotAPI) GetMyCommands(config GetMyCommandsConfig) ([]BotCommand, error) {
+func (bot *BotAPI) GetMyCommands() ([]BotCommand, error) {
+	return bot.GetMyCommandsWithConfig(GetMyCommandsConfig{})
+}
+
+// GetMyCommandsWithConfig gets the currently registered commands with a config.
+func (bot *BotAPI) GetMyCommandsWithConfig(config GetMyCommandsConfig) ([]BotCommand, error) {
 	resp, err := bot.Request(config)
 	if err != nil {
 		return nil, err

--- a/bot_test.go
+++ b/bot_test.go
@@ -953,7 +953,7 @@ func TestSendDice(t *testing.T) {
 	}
 }
 
-func TestSetCommands(t *testing.T) {
+func TestCommands(t *testing.T) {
 	bot, _ := getBot(t)
 
 	setCommands := NewSetMyCommands(BotCommand{
@@ -965,7 +965,7 @@ func TestSetCommands(t *testing.T) {
 		t.Error("Unable to set commands")
 	}
 
-	commands, err := bot.GetMyCommands()
+	commands, err := bot.GetMyCommands(NewGetMyCommands())
 	if err != nil {
 		t.Error("Unable to get commands")
 	}
@@ -975,6 +975,28 @@ func TestSetCommands(t *testing.T) {
 	}
 
 	if commands[0].Command != "test" || commands[0].Description != "a test command" {
+		t.Error("Commands were incorrectly set")
+	}
+
+	setCommands = NewSetMyCommandsWithScope(NewBotCommandScopeAllPrivateChats(), BotCommand{
+		Command:     "private",
+		Description: "a private command",
+	})
+
+	if _, err := bot.Request(setCommands); err != nil {
+		t.Error("Unable to set commands")
+	}
+
+	commands, err = bot.GetMyCommands(NewGetMyCommandsWithScope(NewBotCommandScopeAllPrivateChats()))
+	if err != nil {
+		t.Error("Unable to get commands")
+	}
+
+	if len(commands) != 1 {
+		t.Error("Incorrect number of commands returned")
+	}
+
+	if commands[0].Command != "private" || commands[0].Description != "a private command" {
 		t.Error("Commands were incorrectly set")
 	}
 }

--- a/bot_test.go
+++ b/bot_test.go
@@ -965,7 +965,7 @@ func TestCommands(t *testing.T) {
 		t.Error("Unable to set commands")
 	}
 
-	commands, err := bot.GetMyCommands(NewGetMyCommands())
+	commands, err := bot.GetMyCommands()
 	if err != nil {
 		t.Error("Unable to get commands")
 	}
@@ -987,7 +987,7 @@ func TestCommands(t *testing.T) {
 		t.Error("Unable to set commands")
 	}
 
-	commands, err = bot.GetMyCommands(NewGetMyCommandsWithScope(NewBotCommandScopeAllPrivateChats()))
+	commands, err = bot.GetMyCommandsWithConfig(NewGetMyCommandsWithScope(NewBotCommandScopeAllPrivateChats()))
 	if err != nil {
 		t.Error("Unable to get commands")
 	}

--- a/configs.go
+++ b/configs.go
@@ -2062,19 +2062,29 @@ func (config DiceConfig) params() (Params, error) {
 }
 
 // GetMyCommandsConfig gets a list of the currently registered commands.
-type GetMyCommandsConfig struct{}
+type GetMyCommandsConfig struct {
+	Scope        *BotCommandScope
+	LanguageCode string
+}
 
 func (config GetMyCommandsConfig) method() string {
 	return "getMyCommands"
 }
 
 func (config GetMyCommandsConfig) params() (Params, error) {
-	return nil, nil
+	params := make(Params)
+
+	err := params.AddInterface("scope", config.Scope)
+	params.AddNonEmpty("language_code", config.LanguageCode)
+
+	return params, err
 }
 
 // SetMyCommandsConfig sets a list of commands the bot understands.
 type SetMyCommandsConfig struct {
-	commands []BotCommand
+	Commands     []BotCommand
+	Scope        *BotCommandScope
+	LanguageCode string
 }
 
 func (config SetMyCommandsConfig) method() string {
@@ -2084,7 +2094,29 @@ func (config SetMyCommandsConfig) method() string {
 func (config SetMyCommandsConfig) params() (Params, error) {
 	params := make(Params)
 
-	err := params.AddInterface("commands", config.commands)
+	if err := params.AddInterface("commands", config.Commands); err != nil {
+		return params, err
+	}
+	err := params.AddInterface("scope", config.Scope)
+	params.AddNonEmpty("language_code", config.LanguageCode)
+
+	return params, err
+}
+
+type DeleteMyCommandsConfig struct {
+	Scope        *BotCommandScope
+	LanguageCode string
+}
+
+func (config DeleteMyCommandsConfig) method() string {
+	return "deleteMyCommands"
+}
+
+func (config DeleteMyCommandsConfig) params() (Params, error) {
+	params := make(Params)
+
+	err := params.AddInterface("scope", config.Scope)
+	params.AddNonEmpty("language_code", config.LanguageCode)
 
 	return params, err
 }

--- a/helpers.go
+++ b/helpers.go
@@ -837,7 +837,103 @@ func NewDiceWithEmoji(chatID int64, emoji string) DiceConfig {
 	}
 }
 
+// NewBotCommandScopeDefault represents the default scope of bot commands.
+func NewBotCommandScopeDefault() BotCommandScope {
+	return BotCommandScope{Type: "default"}
+}
+
+// NewBotCommandScopeAllPrivateChats represents the scope of bot commands,
+// covering all private chats.
+func NewBotCommandScopeAllPrivateChats() BotCommandScope {
+	return BotCommandScope{Type: "all_private_chats"}
+}
+
+// NewBotCommandScopeAllGroupChats represents the scope of bot commands,
+// covering all group and supergroup chats.
+func NewBotCommandScopeAllGroupChats() BotCommandScope {
+	return BotCommandScope{Type: "all_group_chats"}
+}
+
+// NewBotCommandScopeAllChatAdministrators represents the scope of bot commands,
+// covering all group and supergroup chat administrators.
+func NewBotCommandScopeAllChatAdministrators() BotCommandScope {
+	return BotCommandScope{Type: "all_chat_administrators"}
+}
+
+// NewBotCommandScopeChat represents the scope of bot commands, covering a
+// specific chat.
+func NewBotCommandScopeChat(chatID int64) BotCommandScope {
+	return BotCommandScope{
+		Type:   "chat",
+		ChatID: chatID,
+	}
+}
+
+// NewBotCommandScopeChatAdministrators represents the scope of bot commands,
+// covering all administrators of a specific group or supergroup chat.
+func NewBotCommandScopeChatAdministrators(chatID int64) BotCommandScope {
+	return BotCommandScope{
+		Type:   "chat_administrators",
+		ChatID: chatID,
+	}
+}
+
+// NewBotCommandScopeChatMember represents the scope of bot commands, covering a
+// specific member of a group or supergroup chat.
+func NewBotCommandScopeChatMember(chatID, userID int64) BotCommandScope {
+	return BotCommandScope{
+		Type:   "chat_member",
+		ChatID: chatID,
+		UserID: userID,
+	}
+}
+
+// NewGetMyCommands allows you to set the registered commands.
+func NewGetMyCommands() GetMyCommandsConfig {
+	return GetMyCommandsConfig{}
+}
+
+// NewGetMyCommandsWithScope allows you to set the registered commands for a
+// given scope.
+func NewGetMyCommandsWithScope(scope BotCommandScope) GetMyCommandsConfig {
+	return GetMyCommandsConfig{Scope: &scope}
+}
+
+// NewGetMyCommandsWithScopeAndLanguage allows you to set the registered
+// commands for a given scope and language code.
+func NewGetMyCommandsWithScopeAndLanguage(scope BotCommandScope, languageCode string) GetMyCommandsConfig {
+	return GetMyCommandsConfig{Scope: &scope, LanguageCode: languageCode}
+}
+
 // NewSetMyCommands allows you to set the registered commands.
 func NewSetMyCommands(commands ...BotCommand) SetMyCommandsConfig {
-	return SetMyCommandsConfig{commands: commands}
+	return SetMyCommandsConfig{Commands: commands}
+}
+
+// NewSetMyCommands allows you to set the registered commands for a given scope.
+func NewSetMyCommandsWithScope(scope BotCommandScope, commands ...BotCommand) SetMyCommandsConfig {
+	return SetMyCommandsConfig{Commands: commands, Scope: &scope}
+}
+
+// NewSetMyCommands allows you to set the registered commands for a given scope
+// and language code.
+func NewSetMyCommandsWithScopeAndLanguage(scope BotCommandScope, languageCode string, commands ...BotCommand) SetMyCommandsConfig {
+	return SetMyCommandsConfig{Commands: commands, Scope: &scope, LanguageCode: languageCode}
+}
+
+// NewDeleteMyCommands allows you to delete the registered commands.
+func NewDeleteMyCommands() DeleteMyCommandsConfig {
+	return DeleteMyCommandsConfig{}
+}
+
+// NewDeleteMyCommands allows you to delete the registered commands for a given
+// scope.
+func NewDeleteMyCommandsWithScope(scope BotCommandScope) DeleteMyCommandsConfig {
+	return DeleteMyCommandsConfig{Scope: &scope}
+}
+
+// NewDeleteMyCommands allows you to delete the registered commands for a given
+// scope and language code.
+func NewDeleteMyCommandsWithScopeAndLanguage(scope BotCommandScope, languageCode string) DeleteMyCommandsConfig {
+	return DeleteMyCommandsConfig{Scope: &scope, LanguageCode: languageCode}
 }

--- a/helpers.go
+++ b/helpers.go
@@ -888,11 +888,6 @@ func NewBotCommandScopeChatMember(chatID, userID int64) BotCommandScope {
 	}
 }
 
-// NewGetMyCommands allows you to set the registered commands.
-func NewGetMyCommands() GetMyCommandsConfig {
-	return GetMyCommandsConfig{}
-}
-
 // NewGetMyCommandsWithScope allows you to set the registered commands for a
 // given scope.
 func NewGetMyCommandsWithScope(scope BotCommandScope) GetMyCommandsConfig {

--- a/types.go
+++ b/types.go
@@ -1158,6 +1158,11 @@ type ReplyKeyboardMarkup struct {
 	//
 	// optional
 	OneTimeKeyboard bool `json:"one_time_keyboard,omitempty"`
+	// InputFieldPlaceholder is the placeholder to be shown in the input field when
+	// the keyboard is active; 1-64 characters.
+	//
+	// optional
+	InputFieldPlaceholder string `json:"input_field_placeholder,omitempty"`
 	// Selective use this parameter if you want to show the keyboard to specific users only.
 	// Targets:
 	//  1) users that are @mentioned in the text of the Message object;
@@ -1375,6 +1380,11 @@ type ForceReply struct {
 	// ForceReply shows reply interface to the user,
 	// as if they manually selected the bot's message and tapped 'Reply'.
 	ForceReply bool `json:"force_reply"`
+	// InputFieldPlaceholder is the placeholder to be shown in the input field when
+	// the reply is active; 1-64 characters.
+	//
+	// optional
+	InputFieldPlaceholder string `json:"input_field_placeholder,omitempty"`
 	// Selective use this parameter if you want to force reply from specific users only.
 	// Targets:
 	//  1) users that are @mentioned in the text of the Message object;
@@ -1641,6 +1651,16 @@ type BotCommand struct {
 	Command string `json:"command"`
 	// Description of the command, 3-256 characters.
 	Description string `json:"description"`
+}
+
+// BotCommandScope represents the scope to which bot commands are applied.
+//
+// It contains the fields for all types of scopes, different types only support
+// specific (or no) fields.
+type BotCommandScope struct {
+	Type   string `json:"type"`
+	ChatID int64  `json:"chat_id,omitempty"`
+	UserID int64  `json:"user_id,omitempty"`
 }
 
 // ResponseParameters are various errors that can be returned in APIResponse.

--- a/types_test.go
+++ b/types_test.go
@@ -293,6 +293,7 @@ var (
 	_ Chattable = DeleteChatPhotoConfig{}
 	_ Chattable = DeleteChatStickerSetConfig{}
 	_ Chattable = DeleteMessageConfig{}
+	_ Chattable = DeleteMyCommandsConfig{}
 	_ Chattable = DeleteWebhookConfig{}
 	_ Chattable = DocumentConfig{}
 	_ Chattable = EditChatInviteLinkConfig{}


### PR DESCRIPTION
- Adds `scope` and `language_code` to `setMyCommands` and `getMyCommands`
- Adds `deleteMyCommands`
- Adds `input_field_placeholder` to `ReplyKeyboardMarkup` and `ForceReply`

Things still needing consideration:
- `ChatMember` was split into multiple classes, how should this be reflected in the library?
- `kickChatMember` and `getChatMembersCount` were renamed to `banChatMember` and `getChatMemberCount` without plans for deprecation. Should this be changed (maybe create an alias)? 