### PR TITLE
Updates for Bot API 5.6

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -266,6 +266,7 @@ func (CloseConfig) params() (Params, error) {
 type BaseChat struct {
 	ChatID                   int64 // required
 	ChannelUsername          string
+	ProtectContent           bool
 	ReplyToMessageID         int
 	ReplyMarkup              interface{}
 	DisableNotification      bool
@@ -279,6 +280,7 @@ func (chat *BaseChat) params() (Params, error) {
 	params.AddNonZero("reply_to_message_id", chat.ReplyToMessageID)
 	params.AddBool("disable_notification", chat.DisableNotification)
 	params.AddBool("allow_sending_without_reply", chat.AllowSendingWithoutReply)
+	params.AddBool("protect_content", chat.ProtectContent)
 
 	err := params.AddInterface("reply_markup", chat.ReplyMarkup)
 

--- a/types.go
+++ b/types.go
@@ -712,6 +712,7 @@ type MessageEntity struct {
 	//  “italic” (italic text),
 	//  “underline” (underlined text),
 	//  “strikethrough” (strikethrough text),
+	//  "spoiler" (spoiler message),
 	//  “code” (monowidth string),
 	//  “pre” (monowidth block),
 	//  “text_link” (for clickable text URLs),


### PR DESCRIPTION
- Add `protect_content` field to `BaseChat`, which covers all methods that accept this parameter
- Document spoiler type for message entities