### PR TITLE
Fix file handling in WriteToHTTPResponse

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -539,8 +539,14 @@ func WriteToHTTPResponse(w http.ResponseWriter, c Chattable) error {
 	}
 
 	if t, ok := c.(Fileable); ok {
-		if hasFilesNeedingUpload(t.files()) {
+		files := t.files()
+
+		if hasFilesNeedingUpload(files) {
 			return errors.New("unable to use http response to upload files")
+		}
+
+		for _, file := range files {
+			params[file.Name] = file.Data.SendData()
 		}
 	}
 


### PR DESCRIPTION
#356 updates the logic to support uploading multiple files but accidentally breaks this.