### PR TITLE
Close hanging channel in ListenForWebhookRespReqFormat

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -494,6 +494,8 @@ func (bot *BotAPI) ListenForWebhookRespReqFormat(w http.ResponseWriter, r *http.
 	ch := make(chan Update, bot.Buffer)
 
 	func(w http.ResponseWriter, r *http.Request) {
+		defer close(ch)
+
 		update, err := bot.HandleUpdate(r)
 		if err != nil {
 			errMsg, _ := json.Marshal(map[string]string{"error": err.Error()})
@@ -504,7 +506,6 @@ func (bot *BotAPI) ListenForWebhookRespReqFormat(w http.ResponseWriter, r *http.
 		}
 
 		ch <- *update
-		close(ch)
 	}(w, r)
 
 	return ch


### PR DESCRIPTION
When an error occurs while handling an update in ListenForWebhookRespReqFormat, the update channel remains open and causes a subsequent range for loop to hang indefinitely.