### PR TITLE
feat: add IsTextMention to MessageEntity

### DIFF
--- a/types.go
+++ b/types.go
@@ -754,6 +754,12 @@ func (e MessageEntity) IsMention() bool {
 	return e.Type == "mention"
 }
 
+// IsTextMention returns true if the type of the message entity is "text_mention"
+// (At this time, the user field exists, and occurs when tagging a member without a username)
+func (e MessageEntity) IsTextMention() bool {
+	return e.Type == "text_mention"
+}
+
 // IsHashtag returns true if the type of the message entity is "hashtag".
 func (e MessageEntity) IsHashtag() bool {
 	return e.Type == "hashtag"


### PR DESCRIPTION

This works when we tag a member without a username, It is different from a mention.

```go
for _, entity := range message.Entities {
	if entity.IsTextMention() {
		println(entity.User.ID)
	}
	if entity.IsMention() {
		println(message.Text[entity.Offset:entity.Offset+entity.Length])
	}
}
```