### PR TITLE
Remove deprecated ioutil functions

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -151,7 +150,7 @@ func (bot *BotAPI) decodeAPIResponse(responseBody io.Reader, resp *APIResponse) 
 	}
 
 	// if debug, read response body
-	data, err := ioutil.ReadAll(responseBody)
+	data, err := io.ReadAll(responseBody)
 	if err != nil {
 		return nil, err
 	}

--- a/bot_test.go
+++ b/bot_test.go
@@ -1,7 +1,6 @@
 package tgbotapi
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -139,7 +138,7 @@ func TestSendWithNewPhoto(t *testing.T) {
 func TestSendWithNewPhotoWithFileBytes(t *testing.T) {
 	bot, _ := getBot(t)
 
-	data, _ := ioutil.ReadFile("tests/image.jpg")
+	data, _ := os.ReadFile("tests/image.jpg")
 	b := FileBytes{Name: "image.jpg", Bytes: data}
 
 	msg := NewPhoto(ChatID, b)
@@ -195,7 +194,7 @@ func TestSendNewPhotoToChannel(t *testing.T) {
 func TestSendNewPhotoToChannelFileBytes(t *testing.T) {
 	bot, _ := getBot(t)
 
-	data, _ := ioutil.ReadFile("tests/image.jpg")
+	data, _ := os.ReadFile("tests/image.jpg")
 	b := FileBytes{Name: "image.jpg", Bytes: data}
 
 	msg := NewPhotoToChannel(Channel, b)


### PR DESCRIPTION
This PR replaces deprecated functions in Go 1.16 [`ioutil.ReadFile`](https://pkg.go.dev/io/ioutil#ReadFile) and `ioutil.ReadAll` with `os.ReadFile` and `io.ReadAll`.