### PR TITLE
Use log.Fatal instead of panic in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import (
 func main() {
 	bot, err := tgbotapi.NewBotAPI("MyAwesomeBotToken")
 	if err != nil {
-		log.Panic(err)
+		log.Fatal(err)
 	}
 
 	bot.Debug = true

--- a/docs/examples/command-handling.md
+++ b/docs/examples/command-handling.md
@@ -15,7 +15,7 @@ import (
 func main() {
 	bot, err := tgbotapi.NewBotAPI(os.Getenv("TELEGRAM_APITOKEN"))
 	if err != nil {
-		log.Panic(err)
+		log.Fatal(err)
 	}
 
 	bot.Debug = true
@@ -53,7 +53,7 @@ func main() {
 		}
 
 		if _, err := bot.Send(msg); err != nil {
-			log.Panic(err)
+			log.Fatal(err)
 		}
 	}
 }

--- a/docs/examples/inline-keyboard.md
+++ b/docs/examples/inline-keyboard.md
@@ -30,7 +30,7 @@ var numericKeyboard = tgbotapi.NewInlineKeyboardMarkup(
 func main() {
 	bot, err := tgbotapi.NewBotAPI(os.Getenv("TELEGRAM_APITOKEN"))
 	if err != nil {
-		log.Panic(err)
+		log.Fatal(err)
 	}
 
 	bot.Debug = true
@@ -59,20 +59,20 @@ func main() {
 
 			// Send the message.
 			if _, err = bot.Send(msg); err != nil {
-				panic(err)
+				log.Fatal(err)
 			}
 		} else if update.CallbackQuery != nil {
 			// Respond to the callback query, telling Telegram to show the user
 			// a message with the data received.
 			callback := tgbotapi.NewCallback(update.CallbackQuery.ID, update.CallbackQuery.Data)
 			if _, err := bot.Request(callback); err != nil {
-				panic(err)
+				log.Fatal(err)
 			}
 
 			// And finally, send a message containing the data received.
 			msg := tgbotapi.NewMessage(update.CallbackQuery.Message.Chat.ID, update.CallbackQuery.Data)
 			if _, err := bot.Send(msg); err != nil {
-				panic(err)
+				log.Fatal(err)
 			}
 		}
 	}

--- a/docs/examples/keyboard.md
+++ b/docs/examples/keyboard.md
@@ -29,7 +29,7 @@ var numericKeyboard = tgbotapi.NewReplyKeyboard(
 func main() {
 	bot, err := tgbotapi.NewBotAPI(os.Getenv("TELEGRAM_APITOKEN"))
 	if err != nil {
-		log.Panic(err)
+		log.Fatal(err)
 	}
 
 	bot.Debug = true
@@ -56,7 +56,7 @@ func main() {
 		}
 
 		if _, err := bot.Send(msg); err != nil {
-			log.Panic(err)
+			log.Fatal(err)
 		}
 	}
 }

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -28,6 +28,7 @@ Let's start by constructing a new [BotAPI][bot-api-docs].
 package main
 
 import (
+	"log"
 	"os"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
@@ -36,7 +37,7 @@ import (
 func main() {
 	bot, err := tgbotapi.NewBotAPI(os.Getenv("TELEGRAM_APITOKEN"))
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	bot.Debug = true
@@ -98,7 +99,7 @@ things. We can add this code in right after the line enabling debug mode.
 			// Note that panics are a bad way to handle errors. Telegram can
 			// have service outages or network errors, you should retry sending
 			// messages or more gracefully handle failures.
-			panic(err)
+			log.Fatal(err)
 		}
 	}
 ```


### PR DESCRIPTION
This PR replaces all the usages `panic(err)`, `log.Panic(err)` with `log.Fatal(err)` in the documentation for the sake of consistency.