### PR TITLE
Made the Chattable and Fileable interface methods exportable.

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -311,18 +311,18 @@ func hasFilesNeedingUpload(files []RequestFile) bool {
 
 // Request sends a Chattable to Telegram, and returns the APIResponse.
 func (bot *BotAPI) Request(c Chattable) (*APIResponse, error) {
-	params, err := c.params()
+	params, err := c.Params()
 	if err != nil {
 		return nil, err
 	}
 
 	if t, ok := c.(Fileable); ok {
-		files := t.files()
+		files := t.Files()
 
 		// If we have files that need to be uploaded, we should delegate the
 		// request to UploadFile.
 		if hasFilesNeedingUpload(files) {
-			return bot.UploadFiles(t.method(), params, files)
+			return bot.UploadFiles(t.Method(), params, files)
 		}
 
 		// However, if there are no files to be uploaded, there's likely things
@@ -332,7 +332,7 @@ func (bot *BotAPI) Request(c Chattable) (*APIResponse, error) {
 		}
 	}
 
-	return bot.MakeRequest(c.method(), params)
+	return bot.MakeRequest(c.Method(), params)
 }
 
 // Send will send a Chattable item to Telegram and provides the
@@ -533,19 +533,19 @@ func (bot *BotAPI) HandleUpdate(r *http.Request) (*Update, error) {
 // See https://core.telegram.org/bots/api#making-requests-when-getting-updates
 // for details.
 func WriteToHTTPResponse(w http.ResponseWriter, c Chattable) error {
-	params, err := c.params()
+	params, err := c.Params()
 	if err != nil {
 		return err
 	}
 
 	if t, ok := c.(Fileable); ok {
-		if hasFilesNeedingUpload(t.files()) {
+		if hasFilesNeedingUpload(t.Files()) {
 			return errors.New("unable to use http response to upload files")
 		}
 	}
 
 	values := buildParams(params)
-	values.Set("method", c.method())
+	values.Set("method", c.Method())
 
 	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
 	_, err = w.Write([]byte(values.Encode()))

--- a/configs.go
+++ b/configs.go
@@ -101,14 +101,14 @@ const (
 
 // Chattable is any config type that can be sent.
 type Chattable interface {
-	params() (Params, error)
-	method() string
+	Params() (Params, error)
+	Method() string
 }
 
 // Fileable is any config type that can be sent that includes a file.
 type Fileable interface {
 	Chattable
-	files() []RequestFile
+	Files() []RequestFile
 }
 
 // RequestFile represents a file associated with a field name.
@@ -240,11 +240,11 @@ func (fa fileAttach) SendData() string {
 // Note that you may not log back in for at least 10 minutes.
 type LogOutConfig struct{}
 
-func (LogOutConfig) method() string {
+func (LogOutConfig) Method() string {
 	return "logOut"
 }
 
-func (LogOutConfig) params() (Params, error) {
+func (LogOutConfig) Params() (Params, error) {
 	return nil, nil
 }
 
@@ -254,11 +254,11 @@ func (LogOutConfig) params() (Params, error) {
 // bot has started.
 type CloseConfig struct{}
 
-func (CloseConfig) method() string {
+func (CloseConfig) Method() string {
 	return "close"
 }
 
-func (CloseConfig) params() (Params, error) {
+func (CloseConfig) Params() (Params, error) {
 	return nil, nil
 }
 
@@ -293,7 +293,7 @@ type BaseFile struct {
 	File RequestFileData
 }
 
-func (file BaseFile) params() (Params, error) {
+func (file BaseFile) Params() (Params, error) {
 	return file.BaseChat.params()
 }
 
@@ -330,7 +330,7 @@ type MessageConfig struct {
 	DisableWebPagePreview bool
 }
 
-func (config MessageConfig) params() (Params, error) {
+func (config MessageConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 	if err != nil {
 		return params, err
@@ -344,7 +344,7 @@ func (config MessageConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config MessageConfig) method() string {
+func (config MessageConfig) Method() string {
 	return "sendMessage"
 }
 
@@ -356,7 +356,7 @@ type ForwardConfig struct {
 	MessageID           int // required
 }
 
-func (config ForwardConfig) params() (Params, error) {
+func (config ForwardConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 	if err != nil {
 		return params, err
@@ -368,7 +368,7 @@ func (config ForwardConfig) params() (Params, error) {
 	return params, nil
 }
 
-func (config ForwardConfig) method() string {
+func (config ForwardConfig) Method() string {
 	return "forwardMessage"
 }
 
@@ -383,7 +383,7 @@ type CopyMessageConfig struct {
 	CaptionEntities     []MessageEntity
 }
 
-func (config CopyMessageConfig) params() (Params, error) {
+func (config CopyMessageConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 	if err != nil {
 		return params, err
@@ -398,7 +398,7 @@ func (config CopyMessageConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config CopyMessageConfig) method() string {
+func (config CopyMessageConfig) Method() string {
 	return "copyMessage"
 }
 
@@ -411,8 +411,8 @@ type PhotoConfig struct {
 	CaptionEntities []MessageEntity
 }
 
-func (config PhotoConfig) params() (Params, error) {
-	params, err := config.BaseFile.params()
+func (config PhotoConfig) Params() (Params, error) {
+	params, err := config.BaseFile.Params()
 	if err != nil {
 		return params, err
 	}
@@ -424,11 +424,11 @@ func (config PhotoConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config PhotoConfig) method() string {
+func (config PhotoConfig) Method() string {
 	return "sendPhoto"
 }
 
-func (config PhotoConfig) files() []RequestFile {
+func (config PhotoConfig) Files() []RequestFile {
 	files := []RequestFile{{
 		Name: "photo",
 		Data: config.File,
@@ -456,7 +456,7 @@ type AudioConfig struct {
 	Title           string
 }
 
-func (config AudioConfig) params() (Params, error) {
+func (config AudioConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 	if err != nil {
 		return params, err
@@ -472,11 +472,11 @@ func (config AudioConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config AudioConfig) method() string {
+func (config AudioConfig) Method() string {
 	return "sendAudio"
 }
 
-func (config AudioConfig) files() []RequestFile {
+func (config AudioConfig) Files() []RequestFile {
 	files := []RequestFile{{
 		Name: "audio",
 		Data: config.File,
@@ -502,8 +502,8 @@ type DocumentConfig struct {
 	DisableContentTypeDetection bool
 }
 
-func (config DocumentConfig) params() (Params, error) {
-	params, err := config.BaseFile.params()
+func (config DocumentConfig) Params() (Params, error) {
+	params, err := config.BaseFile.Params()
 
 	params.AddNonEmpty("caption", config.Caption)
 	params.AddNonEmpty("parse_mode", config.ParseMode)
@@ -512,11 +512,11 @@ func (config DocumentConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config DocumentConfig) method() string {
+func (config DocumentConfig) Method() string {
 	return "sendDocument"
 }
 
-func (config DocumentConfig) files() []RequestFile {
+func (config DocumentConfig) Files() []RequestFile {
 	files := []RequestFile{{
 		Name: "document",
 		Data: config.File,
@@ -537,15 +537,15 @@ type StickerConfig struct {
 	BaseFile
 }
 
-func (config StickerConfig) params() (Params, error) {
+func (config StickerConfig) Params() (Params, error) {
 	return config.BaseChat.params()
 }
 
-func (config StickerConfig) method() string {
+func (config StickerConfig) Method() string {
 	return "sendSticker"
 }
 
-func (config StickerConfig) files() []RequestFile {
+func (config StickerConfig) Files() []RequestFile {
 	return []RequestFile{{
 		Name: "sticker",
 		Data: config.File,
@@ -563,7 +563,7 @@ type VideoConfig struct {
 	SupportsStreaming bool
 }
 
-func (config VideoConfig) params() (Params, error) {
+func (config VideoConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 	if err != nil {
 		return params, err
@@ -578,11 +578,11 @@ func (config VideoConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config VideoConfig) method() string {
+func (config VideoConfig) Method() string {
 	return "sendVideo"
 }
 
-func (config VideoConfig) files() []RequestFile {
+func (config VideoConfig) Files() []RequestFile {
 	files := []RequestFile{{
 		Name: "video",
 		Data: config.File,
@@ -608,7 +608,7 @@ type AnimationConfig struct {
 	CaptionEntities []MessageEntity
 }
 
-func (config AnimationConfig) params() (Params, error) {
+func (config AnimationConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 	if err != nil {
 		return params, err
@@ -622,11 +622,11 @@ func (config AnimationConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config AnimationConfig) method() string {
+func (config AnimationConfig) Method() string {
 	return "sendAnimation"
 }
 
-func (config AnimationConfig) files() []RequestFile {
+func (config AnimationConfig) Files() []RequestFile {
 	files := []RequestFile{{
 		Name: "animation",
 		Data: config.File,
@@ -650,7 +650,7 @@ type VideoNoteConfig struct {
 	Length   int
 }
 
-func (config VideoNoteConfig) params() (Params, error) {
+func (config VideoNoteConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 
 	params.AddNonZero("duration", config.Duration)
@@ -659,11 +659,11 @@ func (config VideoNoteConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config VideoNoteConfig) method() string {
+func (config VideoNoteConfig) Method() string {
 	return "sendVideoNote"
 }
 
-func (config VideoNoteConfig) files() []RequestFile {
+func (config VideoNoteConfig) Files() []RequestFile {
 	files := []RequestFile{{
 		Name: "video_note",
 		Data: config.File,
@@ -689,7 +689,7 @@ type VoiceConfig struct {
 	Duration        int
 }
 
-func (config VoiceConfig) params() (Params, error) {
+func (config VoiceConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 	if err != nil {
 		return params, err
@@ -703,11 +703,11 @@ func (config VoiceConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config VoiceConfig) method() string {
+func (config VoiceConfig) Method() string {
 	return "sendVoice"
 }
 
-func (config VoiceConfig) files() []RequestFile {
+func (config VoiceConfig) Files() []RequestFile {
 	files := []RequestFile{{
 		Name: "voice",
 		Data: config.File,
@@ -734,7 +734,7 @@ type LocationConfig struct {
 	ProximityAlertRadius int     // optional
 }
 
-func (config LocationConfig) params() (Params, error) {
+func (config LocationConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 
 	params.AddNonZeroFloat("latitude", config.Latitude)
@@ -747,7 +747,7 @@ func (config LocationConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config LocationConfig) method() string {
+func (config LocationConfig) Method() string {
 	return "sendLocation"
 }
 
@@ -761,7 +761,7 @@ type EditMessageLiveLocationConfig struct {
 	ProximityAlertRadius int     // optional
 }
 
-func (config EditMessageLiveLocationConfig) params() (Params, error) {
+func (config EditMessageLiveLocationConfig) Params() (Params, error) {
 	params, err := config.BaseEdit.params()
 
 	params.AddNonZeroFloat("latitude", config.Latitude)
@@ -773,7 +773,7 @@ func (config EditMessageLiveLocationConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config EditMessageLiveLocationConfig) method() string {
+func (config EditMessageLiveLocationConfig) Method() string {
 	return "editMessageLiveLocation"
 }
 
@@ -782,11 +782,11 @@ type StopMessageLiveLocationConfig struct {
 	BaseEdit
 }
 
-func (config StopMessageLiveLocationConfig) params() (Params, error) {
+func (config StopMessageLiveLocationConfig) Params() (Params, error) {
 	return config.BaseEdit.params()
 }
 
-func (config StopMessageLiveLocationConfig) method() string {
+func (config StopMessageLiveLocationConfig) Method() string {
 	return "stopMessageLiveLocation"
 }
 
@@ -803,7 +803,7 @@ type VenueConfig struct {
 	GooglePlaceType string
 }
 
-func (config VenueConfig) params() (Params, error) {
+func (config VenueConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 
 	params.AddNonZeroFloat("latitude", config.Latitude)
@@ -818,7 +818,7 @@ func (config VenueConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config VenueConfig) method() string {
+func (config VenueConfig) Method() string {
 	return "sendVenue"
 }
 
@@ -831,7 +831,7 @@ type ContactConfig struct {
 	VCard       string
 }
 
-func (config ContactConfig) params() (Params, error) {
+func (config ContactConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 
 	params["phone_number"] = config.PhoneNumber
@@ -843,7 +843,7 @@ func (config ContactConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config ContactConfig) method() string {
+func (config ContactConfig) Method() string {
 	return "sendContact"
 }
 
@@ -864,7 +864,7 @@ type SendPollConfig struct {
 	IsClosed              bool
 }
 
-func (config SendPollConfig) params() (Params, error) {
+func (config SendPollConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 	if err != nil {
 		return params, err
@@ -888,7 +888,7 @@ func (config SendPollConfig) params() (Params, error) {
 	return params, err
 }
 
-func (SendPollConfig) method() string {
+func (SendPollConfig) Method() string {
 	return "sendPoll"
 }
 
@@ -898,7 +898,7 @@ type GameConfig struct {
 	GameShortName string
 }
 
-func (config GameConfig) params() (Params, error) {
+func (config GameConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 
 	params["game_short_name"] = config.GameShortName
@@ -906,7 +906,7 @@ func (config GameConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config GameConfig) method() string {
+func (config GameConfig) Method() string {
 	return "sendGame"
 }
 
@@ -922,7 +922,7 @@ type SetGameScoreConfig struct {
 	InlineMessageID    string
 }
 
-func (config SetGameScoreConfig) params() (Params, error) {
+func (config SetGameScoreConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddNonZero64("user_id", config.UserID)
@@ -939,7 +939,7 @@ func (config SetGameScoreConfig) params() (Params, error) {
 	return params, nil
 }
 
-func (config SetGameScoreConfig) method() string {
+func (config SetGameScoreConfig) Method() string {
 	return "setGameScore"
 }
 
@@ -952,7 +952,7 @@ type GetGameHighScoresConfig struct {
 	InlineMessageID string
 }
 
-func (config GetGameHighScoresConfig) params() (Params, error) {
+func (config GetGameHighScoresConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddNonZero64("user_id", config.UserID)
@@ -967,7 +967,7 @@ func (config GetGameHighScoresConfig) params() (Params, error) {
 	return params, nil
 }
 
-func (config GetGameHighScoresConfig) method() string {
+func (config GetGameHighScoresConfig) Method() string {
 	return "getGameHighScores"
 }
 
@@ -977,7 +977,7 @@ type ChatActionConfig struct {
 	Action string // required
 }
 
-func (config ChatActionConfig) params() (Params, error) {
+func (config ChatActionConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 
 	params["action"] = config.Action
@@ -985,7 +985,7 @@ func (config ChatActionConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config ChatActionConfig) method() string {
+func (config ChatActionConfig) Method() string {
 	return "sendChatAction"
 }
 
@@ -998,7 +998,7 @@ type EditMessageTextConfig struct {
 	DisableWebPagePreview bool
 }
 
-func (config EditMessageTextConfig) params() (Params, error) {
+func (config EditMessageTextConfig) Params() (Params, error) {
 	params, err := config.BaseEdit.params()
 	if err != nil {
 		return params, err
@@ -1012,7 +1012,7 @@ func (config EditMessageTextConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config EditMessageTextConfig) method() string {
+func (config EditMessageTextConfig) Method() string {
 	return "editMessageText"
 }
 
@@ -1024,7 +1024,7 @@ type EditMessageCaptionConfig struct {
 	CaptionEntities []MessageEntity
 }
 
-func (config EditMessageCaptionConfig) params() (Params, error) {
+func (config EditMessageCaptionConfig) Params() (Params, error) {
 	params, err := config.BaseEdit.params()
 	if err != nil {
 		return params, err
@@ -1037,7 +1037,7 @@ func (config EditMessageCaptionConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config EditMessageCaptionConfig) method() string {
+func (config EditMessageCaptionConfig) Method() string {
 	return "editMessageCaption"
 }
 
@@ -1048,11 +1048,11 @@ type EditMessageMediaConfig struct {
 	Media interface{}
 }
 
-func (EditMessageMediaConfig) method() string {
+func (EditMessageMediaConfig) Method() string {
 	return "editMessageMedia"
 }
 
-func (config EditMessageMediaConfig) params() (Params, error) {
+func (config EditMessageMediaConfig) Params() (Params, error) {
 	params, err := config.BaseEdit.params()
 	if err != nil {
 		return params, err
@@ -1063,7 +1063,7 @@ func (config EditMessageMediaConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config EditMessageMediaConfig) files() []RequestFile {
+func (config EditMessageMediaConfig) Files() []RequestFile {
 	return prepareInputMediaFile(config.Media, 0)
 }
 
@@ -1073,11 +1073,11 @@ type EditMessageReplyMarkupConfig struct {
 	BaseEdit
 }
 
-func (config EditMessageReplyMarkupConfig) params() (Params, error) {
+func (config EditMessageReplyMarkupConfig) Params() (Params, error) {
 	return config.BaseEdit.params()
 }
 
-func (config EditMessageReplyMarkupConfig) method() string {
+func (config EditMessageReplyMarkupConfig) Method() string {
 	return "editMessageReplyMarkup"
 }
 
@@ -1086,11 +1086,11 @@ type StopPollConfig struct {
 	BaseEdit
 }
 
-func (config StopPollConfig) params() (Params, error) {
+func (config StopPollConfig) Params() (Params, error) {
 	return config.BaseEdit.params()
 }
 
-func (StopPollConfig) method() string {
+func (StopPollConfig) Method() string {
 	return "stopPoll"
 }
 
@@ -1102,11 +1102,11 @@ type UserProfilePhotosConfig struct {
 	Limit  int
 }
 
-func (UserProfilePhotosConfig) method() string {
+func (UserProfilePhotosConfig) Method() string {
 	return "getUserProfilePhotos"
 }
 
-func (config UserProfilePhotosConfig) params() (Params, error) {
+func (config UserProfilePhotosConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddNonZero64("user_id", config.UserID)
@@ -1121,11 +1121,11 @@ type FileConfig struct {
 	FileID string
 }
 
-func (FileConfig) method() string {
+func (FileConfig) Method() string {
 	return "getFile"
 }
 
-func (config FileConfig) params() (Params, error) {
+func (config FileConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params["file_id"] = config.FileID
@@ -1141,11 +1141,11 @@ type UpdateConfig struct {
 	AllowedUpdates []string
 }
 
-func (UpdateConfig) method() string {
+func (UpdateConfig) Method() string {
 	return "getUpdates"
 }
 
-func (config UpdateConfig) params() (Params, error) {
+func (config UpdateConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddNonZero("offset", config.Offset)
@@ -1166,11 +1166,11 @@ type WebhookConfig struct {
 	DropPendingUpdates bool
 }
 
-func (config WebhookConfig) method() string {
+func (config WebhookConfig) Method() string {
 	return "setWebhook"
 }
 
-func (config WebhookConfig) params() (Params, error) {
+func (config WebhookConfig) Params() (Params, error) {
 	params := make(Params)
 
 	if config.URL != nil {
@@ -1185,7 +1185,7 @@ func (config WebhookConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config WebhookConfig) files() []RequestFile {
+func (config WebhookConfig) Files() []RequestFile {
 	if config.Certificate != nil {
 		return []RequestFile{{
 			Name: "certificate",
@@ -1201,11 +1201,11 @@ type DeleteWebhookConfig struct {
 	DropPendingUpdates bool
 }
 
-func (config DeleteWebhookConfig) method() string {
+func (config DeleteWebhookConfig) Method() string {
 	return "deleteWebhook"
 }
 
-func (config DeleteWebhookConfig) params() (Params, error) {
+func (config DeleteWebhookConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddBool("drop_pending_updates", config.DropPendingUpdates)
@@ -1224,11 +1224,11 @@ type InlineConfig struct {
 	SwitchPMParameter string        `json:"switch_pm_parameter"`
 }
 
-func (config InlineConfig) method() string {
+func (config InlineConfig) Method() string {
 	return "answerInlineQuery"
 }
 
-func (config InlineConfig) params() (Params, error) {
+func (config InlineConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params["inline_query_id"] = config.InlineQueryID
@@ -1252,11 +1252,11 @@ type AnswerWebAppQueryConfig struct {
 	Result interface{} `json:"result"`
 }
 
-func (config AnswerWebAppQueryConfig) method() string {
+func (config AnswerWebAppQueryConfig) Method() string {
 	return "answerWebAppQuery"
 }
 
-func (config AnswerWebAppQueryConfig) params() (Params, error) {
+func (config AnswerWebAppQueryConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params["web_app_query_id"] = config.WebAppQueryID
@@ -1274,11 +1274,11 @@ type CallbackConfig struct {
 	CacheTime       int    `json:"cache_time"`
 }
 
-func (config CallbackConfig) method() string {
+func (config CallbackConfig) Method() string {
 	return "answerCallbackQuery"
 }
 
-func (config CallbackConfig) params() (Params, error) {
+func (config CallbackConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params["callback_query_id"] = config.CallbackQueryID
@@ -1305,11 +1305,11 @@ type UnbanChatMemberConfig struct {
 	OnlyIfBanned bool
 }
 
-func (config UnbanChatMemberConfig) method() string {
+func (config UnbanChatMemberConfig) Method() string {
 	return "unbanChatMember"
 }
 
-func (config UnbanChatMemberConfig) params() (Params, error) {
+func (config UnbanChatMemberConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername, config.ChannelUsername)
@@ -1326,11 +1326,11 @@ type BanChatMemberConfig struct {
 	RevokeMessages bool
 }
 
-func (config BanChatMemberConfig) method() string {
+func (config BanChatMemberConfig) Method() string {
 	return "banChatMember"
 }
 
-func (config BanChatMemberConfig) params() (Params, error) {
+func (config BanChatMemberConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername)
@@ -1353,11 +1353,11 @@ type RestrictChatMemberConfig struct {
 	Permissions *ChatPermissions
 }
 
-func (config RestrictChatMemberConfig) method() string {
+func (config RestrictChatMemberConfig) Method() string {
 	return "restrictChatMember"
 }
 
-func (config RestrictChatMemberConfig) params() (Params, error) {
+func (config RestrictChatMemberConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername, config.ChannelUsername)
@@ -1385,11 +1385,11 @@ type PromoteChatMemberConfig struct {
 	CanPromoteMembers   bool
 }
 
-func (config PromoteChatMemberConfig) method() string {
+func (config PromoteChatMemberConfig) Method() string {
 	return "promoteChatMember"
 }
 
-func (config PromoteChatMemberConfig) params() (Params, error) {
+func (config PromoteChatMemberConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername, config.ChannelUsername)
@@ -1417,11 +1417,11 @@ type SetChatAdministratorCustomTitle struct {
 	CustomTitle string
 }
 
-func (SetChatAdministratorCustomTitle) method() string {
+func (SetChatAdministratorCustomTitle) Method() string {
 	return "setChatAdministratorCustomTitle"
 }
 
-func (config SetChatAdministratorCustomTitle) params() (Params, error) {
+func (config SetChatAdministratorCustomTitle) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername, config.ChannelUsername)
@@ -1443,11 +1443,11 @@ type BanChatSenderChatConfig struct {
 	UntilDate       int
 }
 
-func (config BanChatSenderChatConfig) method() string {
+func (config BanChatSenderChatConfig) Method() string {
 	return "banChatSenderChat"
 }
 
-func (config BanChatSenderChatConfig) params() (Params, error) {
+func (config BanChatSenderChatConfig) Params() (Params, error) {
 	params := make(Params)
 
 	_ = params.AddFirstValid("chat_id", config.ChatID, config.ChannelUsername)
@@ -1466,11 +1466,11 @@ type UnbanChatSenderChatConfig struct {
 	SenderChatID    int64
 }
 
-func (config UnbanChatSenderChatConfig) method() string {
+func (config UnbanChatSenderChatConfig) Method() string {
 	return "unbanChatSenderChat"
 }
 
-func (config UnbanChatSenderChatConfig) params() (Params, error) {
+func (config UnbanChatSenderChatConfig) Params() (Params, error) {
 	params := make(Params)
 
 	_ = params.AddFirstValid("chat_id", config.ChatID, config.ChannelUsername)
@@ -1485,7 +1485,7 @@ type ChatConfig struct {
 	SuperGroupUsername string
 }
 
-func (config ChatConfig) params() (Params, error) {
+func (config ChatConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername)
@@ -1498,7 +1498,7 @@ type ChatInfoConfig struct {
 	ChatConfig
 }
 
-func (ChatInfoConfig) method() string {
+func (ChatInfoConfig) Method() string {
 	return "getChat"
 }
 
@@ -1507,7 +1507,7 @@ type ChatMemberCountConfig struct {
 	ChatConfig
 }
 
-func (ChatMemberCountConfig) method() string {
+func (ChatMemberCountConfig) Method() string {
 	return "getChatMembersCount"
 }
 
@@ -1516,7 +1516,7 @@ type ChatAdministratorsConfig struct {
 	ChatConfig
 }
 
-func (ChatAdministratorsConfig) method() string {
+func (ChatAdministratorsConfig) Method() string {
 	return "getChatAdministrators"
 }
 
@@ -1528,11 +1528,11 @@ type SetChatPermissionsConfig struct {
 	Permissions *ChatPermissions
 }
 
-func (SetChatPermissionsConfig) method() string {
+func (SetChatPermissionsConfig) Method() string {
 	return "setChatPermissions"
 }
 
-func (config SetChatPermissionsConfig) params() (Params, error) {
+func (config SetChatPermissionsConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername)
@@ -1548,11 +1548,11 @@ type ChatInviteLinkConfig struct {
 	ChatConfig
 }
 
-func (ChatInviteLinkConfig) method() string {
+func (ChatInviteLinkConfig) Method() string {
 	return "exportChatInviteLink"
 }
 
-func (config ChatInviteLinkConfig) params() (Params, error) {
+func (config ChatInviteLinkConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername)
@@ -1572,11 +1572,11 @@ type CreateChatInviteLinkConfig struct {
 	CreatesJoinRequest bool
 }
 
-func (CreateChatInviteLinkConfig) method() string {
+func (CreateChatInviteLinkConfig) Method() string {
 	return "createChatInviteLink"
 }
 
-func (config CreateChatInviteLinkConfig) params() (Params, error) {
+func (config CreateChatInviteLinkConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddNonEmpty("name", config.Name)
@@ -1600,11 +1600,11 @@ type EditChatInviteLinkConfig struct {
 	CreatesJoinRequest bool
 }
 
-func (EditChatInviteLinkConfig) method() string {
+func (EditChatInviteLinkConfig) Method() string {
 	return "editChatInviteLink"
 }
 
-func (config EditChatInviteLinkConfig) params() (Params, error) {
+func (config EditChatInviteLinkConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername)
@@ -1626,11 +1626,11 @@ type RevokeChatInviteLinkConfig struct {
 	InviteLink string
 }
 
-func (RevokeChatInviteLinkConfig) method() string {
+func (RevokeChatInviteLinkConfig) Method() string {
 	return "revokeChatInviteLink"
 }
 
-func (config RevokeChatInviteLinkConfig) params() (Params, error) {
+func (config RevokeChatInviteLinkConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername)
@@ -1645,11 +1645,11 @@ type ApproveChatJoinRequestConfig struct {
 	UserID int64
 }
 
-func (ApproveChatJoinRequestConfig) method() string {
+func (ApproveChatJoinRequestConfig) Method() string {
 	return "approveChatJoinRequest"
 }
 
-func (config ApproveChatJoinRequestConfig) params() (Params, error) {
+func (config ApproveChatJoinRequestConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername)
@@ -1664,11 +1664,11 @@ type DeclineChatJoinRequest struct {
 	UserID int64
 }
 
-func (DeclineChatJoinRequest) method() string {
+func (DeclineChatJoinRequest) Method() string {
 	return "declineChatJoinRequest"
 }
 
-func (config DeclineChatJoinRequest) params() (Params, error) {
+func (config DeclineChatJoinRequest) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername)
@@ -1683,11 +1683,11 @@ type LeaveChatConfig struct {
 	ChannelUsername string
 }
 
-func (config LeaveChatConfig) method() string {
+func (config LeaveChatConfig) Method() string {
 	return "leaveChat"
 }
 
-func (config LeaveChatConfig) params() (Params, error) {
+func (config LeaveChatConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.ChannelUsername)
@@ -1702,7 +1702,7 @@ type ChatConfigWithUser struct {
 	UserID             int64
 }
 
-func (config ChatConfigWithUser) params() (Params, error) {
+func (config ChatConfigWithUser) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername)
@@ -1716,7 +1716,7 @@ type GetChatMemberConfig struct {
 	ChatConfigWithUser
 }
 
-func (GetChatMemberConfig) method() string {
+func (GetChatMemberConfig) Method() string {
 	return "getChatMember"
 }
 
@@ -1746,7 +1746,7 @@ type InvoiceConfig struct {
 	IsFlexible                bool
 }
 
-func (config InvoiceConfig) params() (Params, error) {
+func (config InvoiceConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 	if err != nil {
 		return params, err
@@ -1780,7 +1780,7 @@ func (config InvoiceConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config InvoiceConfig) method() string {
+func (config InvoiceConfig) Method() string {
 	return "sendInvoice"
 }
 
@@ -1792,11 +1792,11 @@ type ShippingConfig struct {
 	ErrorMessage    string
 }
 
-func (config ShippingConfig) method() string {
+func (config ShippingConfig) Method() string {
 	return "answerShippingQuery"
 }
 
-func (config ShippingConfig) params() (Params, error) {
+func (config ShippingConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params["shipping_query_id"] = config.ShippingQueryID
@@ -1814,11 +1814,11 @@ type PreCheckoutConfig struct {
 	ErrorMessage       string
 }
 
-func (config PreCheckoutConfig) method() string {
+func (config PreCheckoutConfig) Method() string {
 	return "answerPreCheckoutQuery"
 }
 
-func (config PreCheckoutConfig) params() (Params, error) {
+func (config PreCheckoutConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params["pre_checkout_query_id"] = config.PreCheckoutQueryID
@@ -1835,11 +1835,11 @@ type DeleteMessageConfig struct {
 	MessageID       int
 }
 
-func (config DeleteMessageConfig) method() string {
+func (config DeleteMessageConfig) Method() string {
 	return "deleteMessage"
 }
 
-func (config DeleteMessageConfig) params() (Params, error) {
+func (config DeleteMessageConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.ChannelUsername)
@@ -1856,11 +1856,11 @@ type PinChatMessageConfig struct {
 	DisableNotification bool
 }
 
-func (config PinChatMessageConfig) method() string {
+func (config PinChatMessageConfig) Method() string {
 	return "pinChatMessage"
 }
 
-func (config PinChatMessageConfig) params() (Params, error) {
+func (config PinChatMessageConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.ChannelUsername)
@@ -1879,11 +1879,11 @@ type UnpinChatMessageConfig struct {
 	MessageID       int
 }
 
-func (config UnpinChatMessageConfig) method() string {
+func (config UnpinChatMessageConfig) Method() string {
 	return "unpinChatMessage"
 }
 
-func (config UnpinChatMessageConfig) params() (Params, error) {
+func (config UnpinChatMessageConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.ChannelUsername)
@@ -1899,11 +1899,11 @@ type UnpinAllChatMessagesConfig struct {
 	ChannelUsername string
 }
 
-func (config UnpinAllChatMessagesConfig) method() string {
+func (config UnpinAllChatMessagesConfig) Method() string {
 	return "unpinAllChatMessages"
 }
 
-func (config UnpinAllChatMessagesConfig) params() (Params, error) {
+func (config UnpinAllChatMessagesConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.ChannelUsername)
@@ -1916,11 +1916,11 @@ type SetChatPhotoConfig struct {
 	BaseFile
 }
 
-func (config SetChatPhotoConfig) method() string {
+func (config SetChatPhotoConfig) Method() string {
 	return "setChatPhoto"
 }
 
-func (config SetChatPhotoConfig) files() []RequestFile {
+func (config SetChatPhotoConfig) Files() []RequestFile {
 	return []RequestFile{{
 		Name: "photo",
 		Data: config.File,
@@ -1933,11 +1933,11 @@ type DeleteChatPhotoConfig struct {
 	ChannelUsername string
 }
 
-func (config DeleteChatPhotoConfig) method() string {
+func (config DeleteChatPhotoConfig) Method() string {
 	return "deleteChatPhoto"
 }
 
-func (config DeleteChatPhotoConfig) params() (Params, error) {
+func (config DeleteChatPhotoConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.ChannelUsername)
@@ -1953,11 +1953,11 @@ type SetChatTitleConfig struct {
 	Title string
 }
 
-func (config SetChatTitleConfig) method() string {
+func (config SetChatTitleConfig) Method() string {
 	return "setChatTitle"
 }
 
-func (config SetChatTitleConfig) params() (Params, error) {
+func (config SetChatTitleConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.ChannelUsername)
@@ -1974,11 +1974,11 @@ type SetChatDescriptionConfig struct {
 	Description string
 }
 
-func (config SetChatDescriptionConfig) method() string {
+func (config SetChatDescriptionConfig) Method() string {
 	return "setChatDescription"
 }
 
-func (config SetChatDescriptionConfig) params() (Params, error) {
+func (config SetChatDescriptionConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.ChannelUsername)
@@ -1992,11 +1992,11 @@ type GetStickerSetConfig struct {
 	Name string
 }
 
-func (config GetStickerSetConfig) method() string {
+func (config GetStickerSetConfig) Method() string {
 	return "getStickerSet"
 }
 
-func (config GetStickerSetConfig) params() (Params, error) {
+func (config GetStickerSetConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params["name"] = config.Name
@@ -2010,11 +2010,11 @@ type UploadStickerConfig struct {
 	PNGSticker RequestFileData
 }
 
-func (config UploadStickerConfig) method() string {
+func (config UploadStickerConfig) Method() string {
 	return "uploadStickerFile"
 }
 
-func (config UploadStickerConfig) params() (Params, error) {
+func (config UploadStickerConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddNonZero64("user_id", config.UserID)
@@ -2022,7 +2022,7 @@ func (config UploadStickerConfig) params() (Params, error) {
 	return params, nil
 }
 
-func (config UploadStickerConfig) files() []RequestFile {
+func (config UploadStickerConfig) Files() []RequestFile {
 	return []RequestFile{{
 		Name: "png_sticker",
 		Data: config.PNGSticker,
@@ -2043,11 +2043,11 @@ type NewStickerSetConfig struct {
 	MaskPosition  *MaskPosition
 }
 
-func (config NewStickerSetConfig) method() string {
+func (config NewStickerSetConfig) Method() string {
 	return "createNewStickerSet"
 }
 
-func (config NewStickerSetConfig) params() (Params, error) {
+func (config NewStickerSetConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddNonZero64("user_id", config.UserID)
@@ -2063,7 +2063,7 @@ func (config NewStickerSetConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config NewStickerSetConfig) files() []RequestFile {
+func (config NewStickerSetConfig) Files() []RequestFile {
 	if config.PNGSticker != nil {
 		return []RequestFile{{
 			Name: "png_sticker",
@@ -2087,11 +2087,11 @@ type AddStickerConfig struct {
 	MaskPosition *MaskPosition
 }
 
-func (config AddStickerConfig) method() string {
+func (config AddStickerConfig) Method() string {
 	return "addStickerToSet"
 }
 
-func (config AddStickerConfig) params() (Params, error) {
+func (config AddStickerConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddNonZero64("user_id", config.UserID)
@@ -2103,7 +2103,7 @@ func (config AddStickerConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config AddStickerConfig) files() []RequestFile {
+func (config AddStickerConfig) Files() []RequestFile {
 	if config.PNGSticker != nil {
 		return []RequestFile{{
 			Name: "png_sticker",
@@ -2124,11 +2124,11 @@ type SetStickerPositionConfig struct {
 	Position int
 }
 
-func (config SetStickerPositionConfig) method() string {
+func (config SetStickerPositionConfig) Method() string {
 	return "setStickerPositionInSet"
 }
 
-func (config SetStickerPositionConfig) params() (Params, error) {
+func (config SetStickerPositionConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params["sticker"] = config.Sticker
@@ -2142,11 +2142,11 @@ type DeleteStickerConfig struct {
 	Sticker string
 }
 
-func (config DeleteStickerConfig) method() string {
+func (config DeleteStickerConfig) Method() string {
 	return "deleteStickerFromSet"
 }
 
-func (config DeleteStickerConfig) params() (Params, error) {
+func (config DeleteStickerConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params["sticker"] = config.Sticker
@@ -2161,11 +2161,11 @@ type SetStickerSetThumbConfig struct {
 	Thumb  RequestFileData
 }
 
-func (config SetStickerSetThumbConfig) method() string {
+func (config SetStickerSetThumbConfig) Method() string {
 	return "setStickerSetThumb"
 }
 
-func (config SetStickerSetThumbConfig) params() (Params, error) {
+func (config SetStickerSetThumbConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params["name"] = config.Name
@@ -2174,7 +2174,7 @@ func (config SetStickerSetThumbConfig) params() (Params, error) {
 	return params, nil
 }
 
-func (config SetStickerSetThumbConfig) files() []RequestFile {
+func (config SetStickerSetThumbConfig) Files() []RequestFile {
 	return []RequestFile{{
 		Name: "thumb",
 		Data: config.Thumb,
@@ -2189,11 +2189,11 @@ type SetChatStickerSetConfig struct {
 	StickerSetName string
 }
 
-func (config SetChatStickerSetConfig) method() string {
+func (config SetChatStickerSetConfig) Method() string {
 	return "setChatStickerSet"
 }
 
-func (config SetChatStickerSetConfig) params() (Params, error) {
+func (config SetChatStickerSetConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername)
@@ -2208,11 +2208,11 @@ type DeleteChatStickerSetConfig struct {
 	SuperGroupUsername string
 }
 
-func (config DeleteChatStickerSetConfig) method() string {
+func (config DeleteChatStickerSetConfig) Method() string {
 	return "deleteChatStickerSet"
 }
 
-func (config DeleteChatStickerSetConfig) params() (Params, error) {
+func (config DeleteChatStickerSetConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.SuperGroupUsername)
@@ -2232,11 +2232,11 @@ type MediaGroupConfig struct {
 	ReplyToMessageID    int
 }
 
-func (config MediaGroupConfig) method() string {
+func (config MediaGroupConfig) Method() string {
 	return "sendMediaGroup"
 }
 
-func (config MediaGroupConfig) params() (Params, error) {
+func (config MediaGroupConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", config.ChatID, config.ChannelUsername)
@@ -2248,7 +2248,7 @@ func (config MediaGroupConfig) params() (Params, error) {
 	return params, err
 }
 
-func (config MediaGroupConfig) files() []RequestFile {
+func (config MediaGroupConfig) Files() []RequestFile {
 	return prepareInputMediaForFiles(config.Media)
 }
 
@@ -2263,11 +2263,11 @@ type DiceConfig struct {
 	Emoji string
 }
 
-func (config DiceConfig) method() string {
+func (config DiceConfig) Method() string {
 	return "sendDice"
 }
 
-func (config DiceConfig) params() (Params, error) {
+func (config DiceConfig) Params() (Params, error) {
 	params, err := config.BaseChat.params()
 	if err != nil {
 		return params, err
@@ -2284,11 +2284,11 @@ type GetMyCommandsConfig struct {
 	LanguageCode string
 }
 
-func (config GetMyCommandsConfig) method() string {
+func (config GetMyCommandsConfig) Method() string {
 	return "getMyCommands"
 }
 
-func (config GetMyCommandsConfig) params() (Params, error) {
+func (config GetMyCommandsConfig) Params() (Params, error) {
 	params := make(Params)
 
 	err := params.AddInterface("scope", config.Scope)
@@ -2304,11 +2304,11 @@ type SetMyCommandsConfig struct {
 	LanguageCode string
 }
 
-func (config SetMyCommandsConfig) method() string {
+func (config SetMyCommandsConfig) Method() string {
 	return "setMyCommands"
 }
 
-func (config SetMyCommandsConfig) params() (Params, error) {
+func (config SetMyCommandsConfig) Params() (Params, error) {
 	params := make(Params)
 
 	if err := params.AddInterface("commands", config.Commands); err != nil {
@@ -2325,11 +2325,11 @@ type DeleteMyCommandsConfig struct {
 	LanguageCode string
 }
 
-func (config DeleteMyCommandsConfig) method() string {
+func (config DeleteMyCommandsConfig) Method() string {
 	return "deleteMyCommands"
 }
 
-func (config DeleteMyCommandsConfig) params() (Params, error) {
+func (config DeleteMyCommandsConfig) Params() (Params, error) {
 	params := make(Params)
 
 	err := params.AddInterface("scope", config.Scope)
@@ -2347,11 +2347,11 @@ type SetChatMenuButtonConfig struct {
 	MenuButton *MenuButton
 }
 
-func (config SetChatMenuButtonConfig) method() string {
+func (config SetChatMenuButtonConfig) Method() string {
 	return "setChatMenuButton"
 }
 
-func (config SetChatMenuButtonConfig) params() (Params, error) {
+func (config SetChatMenuButtonConfig) Params() (Params, error) {
 	params := make(Params)
 
 	if err := params.AddFirstValid("chat_id", config.ChatID, config.ChannelUsername); err != nil {
@@ -2367,11 +2367,11 @@ type GetChatMenuButtonConfig struct {
 	ChannelUsername string
 }
 
-func (config GetChatMenuButtonConfig) method() string {
+func (config GetChatMenuButtonConfig) Method() string {
 	return "getChatMenuButton"
 }
 
-func (config GetChatMenuButtonConfig) params() (Params, error) {
+func (config GetChatMenuButtonConfig) Params() (Params, error) {
 	params := make(Params)
 
 	err := params.AddFirstValid("chat_id", config.ChatID, config.ChannelUsername)
@@ -2384,11 +2384,11 @@ type SetMyDefaultAdministratorRightsConfig struct {
 	ForChannels bool
 }
 
-func (config SetMyDefaultAdministratorRightsConfig) method() string {
+func (config SetMyDefaultAdministratorRightsConfig) Method() string {
 	return "setMyDefaultAdministratorRights"
 }
 
-func (config SetMyDefaultAdministratorRightsConfig) params() (Params, error) {
+func (config SetMyDefaultAdministratorRightsConfig) Params() (Params, error) {
 	params := make(Params)
 
 	err := params.AddInterface("rights", config.Rights)
@@ -2401,11 +2401,11 @@ type GetMyDefaultAdministratorRightsConfig struct {
 	ForChannels bool
 }
 
-func (config GetMyDefaultAdministratorRightsConfig) method() string {
+func (config GetMyDefaultAdministratorRightsConfig) Method() string {
 	return "getMyDefaultAdministratorRights"
 }
 
-func (config GetMyDefaultAdministratorRightsConfig) params() (Params, error) {
+func (config GetMyDefaultAdministratorRightsConfig) Params() (Params, error) {
 	params := make(Params)
 
 	params.AddBool("for_channels", config.ForChannels)


### PR DESCRIPTION
It is very strange that these interfaces could not be implemented outside the package in the first place.
Since many methods are not represented in the package (`answerCallbackQuery` for example), there is obviously a need to create the methods by yourself and it would be very convenient to be able to make requests through `Request(c Chattable)`.
