### PR TITLE
added resize photo function to helpers.go #600

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/go-telegram-bot-api/telegram-bot-api/v5
 
 go 1.16
+
+require github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=


### PR DESCRIPTION
This is a fix to solve Issue 600. Resolves https://github.com/go-telegram-bot-api/telegram-bot-api/issues/600. Added a function named ResizePhoto in helpers.go to help developers resize their images in-place to meet telegram conditions. 