### PR TITLE
add message_thread_id to BaseChat entity

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -267,6 +267,7 @@ type BaseChat struct {
 	ChatID                   int64 // required
 	ChannelUsername          string
 	ProtectContent           bool
+	MessageThreadID          int
 	ReplyToMessageID         int
 	ReplyMarkup              interface{}
 	DisableNotification      bool
@@ -278,6 +279,7 @@ func (chat *BaseChat) params() (Params, error) {
 
 	params.AddFirstValid("chat_id", chat.ChatID, chat.ChannelUsername)
 	params.AddNonZero("reply_to_message_id", chat.ReplyToMessageID)
+	params.AddNonZero("message_thread_id", chat.MessageThreadID)
 	params.AddBool("disable_notification", chat.DisableNotification)
 	params.AddBool("allow_sending_without_reply", chat.AllowSendingWithoutReply)
 	params.AddBool("protect_content", chat.ProtectContent)

--- a/types.go
+++ b/types.go
@@ -409,6 +409,10 @@ type Message struct {
 	//
 	// optional
 	IsAutomaticForward bool `json:"is_automatic_forward,omitempty"`
+	// MessageThreadID Unique identifier for the target message thread (topic) of the forum; for forum supergroups only.
+	//
+	// optional
+	MessageThreadID int `json:"message_thread_id,omitempty"`
 	// ReplyToMessage for replies, the original message.
 	// Note that the Message object in this field will not contain further ReplyToMessage fields
 	// even if it itself is a reply;


### PR DESCRIPTION
Add minimal functional for unique identifier for the target message thread (topic) of the forum, for forum supergroups only.