### PR TITLE
AddedToAttachmentMenu update for User type

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ func main() {
 
 	log.Printf("Authorized on account %s", bot.Self.UserName)
 
-	wh, _ := tgbotapi.NewWebhookWithCert("https://www.example.com:8443/"+bot.Token, "cert.pem")
+	wh, _ := tgbotapi.NewWebhookWithCert("https://www.example.com:8443/"+bot.Token, tgbotapi.FilePath("cert.pem"))
 
 	_, err = bot.Request(wh)
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -202,6 +202,10 @@ type User struct {
 	//
 	// optional
 	LanguageCode string `json:"language_code,omitempty"`
+	// True, if this user added the bot to the attachment menu
+	//
+	//	optional
+	AddedToAttachmentMenu bool
 	// CanJoinGroups is true, if the bot can be invited to groups.
 	// Returned only in getMe.
 	//


### PR DESCRIPTION
Add "AddedToAttachmentMenu" field in User type and fix webhook example in README file (use tgbotapi.FilePath("cert.pem") instead of "cert.pem" in tgbotapi.NewWebhookWithCert)