### PR TITLE
If the token is invalid tests segfault

### DIFF
--- a/bot_test.go
+++ b/bot_test.go
@@ -36,14 +36,15 @@ func (t testLogger) Printf(format string, v ...interface{}) {
 
 func getBot(t *testing.T) (*BotAPI, error) {
 	bot, err := NewBotAPI(TestToken)
+
+	if err != nil {
+		return nil, err
+	}
+
 	bot.Debug = true
 
 	logger := testLogger{t}
 	SetLogger(logger)
-
-	if err != nil {
-		t.Error(err)
-	}
 
 	return bot, err
 }
@@ -57,11 +58,16 @@ func TestNewBotAPI_notoken(t *testing.T) {
 }
 
 func TestGetUpdates(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	u := NewUpdate(0)
 
-	_, err := bot.GetUpdates(u)
+	_, err = bot.GetUpdates(u)
 
 	if err != nil {
 		t.Error(err)
@@ -69,11 +75,16 @@ func TestGetUpdates(t *testing.T) {
 }
 
 func TestSendWithMessage(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewMessage(ChatID, "A test message from the test library in telegram-bot-api")
 	msg.ParseMode = ModeMarkdown
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -81,11 +92,16 @@ func TestSendWithMessage(t *testing.T) {
 }
 
 func TestSendWithMessageReply(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewMessage(ChatID, "A test message from the test library in telegram-bot-api")
 	msg.ReplyToMessageID = ReplyToMessageID
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -93,10 +109,15 @@ func TestSendWithMessageReply(t *testing.T) {
 }
 
 func TestSendWithMessageForward(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewForward(ChatID, ChatID, ReplyToMessageID)
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -104,7 +125,12 @@ func TestSendWithMessageForward(t *testing.T) {
 }
 
 func TestCopyMessage(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewMessage(ChatID, "A test message from the test library in telegram-bot-api")
 	message, err := bot.Send(msg)
@@ -124,11 +150,16 @@ func TestCopyMessage(t *testing.T) {
 }
 
 func TestSendWithNewPhoto(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewPhoto(ChatID, FilePath("tests/image.jpg"))
 	msg.Caption = "Test"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -136,14 +167,19 @@ func TestSendWithNewPhoto(t *testing.T) {
 }
 
 func TestSendWithNewPhotoWithFileBytes(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	data, _ := os.ReadFile("tests/image.jpg")
 	b := FileBytes{Name: "image.jpg", Bytes: data}
 
 	msg := NewPhoto(ChatID, b)
 	msg.Caption = "Test"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -151,14 +187,19 @@ func TestSendWithNewPhotoWithFileBytes(t *testing.T) {
 }
 
 func TestSendWithNewPhotoWithFileReader(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	f, _ := os.Open("tests/image.jpg")
 	reader := FileReader{Name: "image.jpg", Reader: f}
 
 	msg := NewPhoto(ChatID, reader)
 	msg.Caption = "Test"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -166,12 +207,17 @@ func TestSendWithNewPhotoWithFileReader(t *testing.T) {
 }
 
 func TestSendWithNewPhotoReply(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewPhoto(ChatID, FilePath("tests/image.jpg"))
 	msg.ReplyToMessageID = ReplyToMessageID
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -179,11 +225,16 @@ func TestSendWithNewPhotoReply(t *testing.T) {
 }
 
 func TestSendNewPhotoToChannel(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewPhotoToChannel(Channel, FilePath("tests/image.jpg"))
 	msg.Caption = "Test"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -192,14 +243,18 @@ func TestSendNewPhotoToChannel(t *testing.T) {
 }
 
 func TestSendNewPhotoToChannelFileBytes(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	data, _ := os.ReadFile("tests/image.jpg")
 	b := FileBytes{Name: "image.jpg", Bytes: data}
 
 	msg := NewPhotoToChannel(Channel, b)
 	msg.Caption = "Test"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -208,14 +263,19 @@ func TestSendNewPhotoToChannelFileBytes(t *testing.T) {
 }
 
 func TestSendNewPhotoToChannelFileReader(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	f, _ := os.Open("tests/image.jpg")
 	reader := FileReader{Name: "image.jpg", Reader: f}
 
 	msg := NewPhotoToChannel(Channel, reader)
 	msg.Caption = "Test"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -224,11 +284,16 @@ func TestSendNewPhotoToChannelFileReader(t *testing.T) {
 }
 
 func TestSendWithExistingPhoto(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewPhoto(ChatID, FileID(ExistingPhotoFileID))
 	msg.Caption = "Test"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -236,10 +301,15 @@ func TestSendWithExistingPhoto(t *testing.T) {
 }
 
 func TestSendWithNewDocument(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewDocument(ChatID, FilePath("tests/image.jpg"))
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -247,11 +317,16 @@ func TestSendWithNewDocument(t *testing.T) {
 }
 
 func TestSendWithNewDocumentAndThumb(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewDocument(ChatID, FilePath("tests/voice.ogg"))
 	msg.Thumb = FilePath("tests/image.jpg")
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -259,10 +334,15 @@ func TestSendWithNewDocumentAndThumb(t *testing.T) {
 }
 
 func TestSendWithExistingDocument(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewDocument(ChatID, FileID(ExistingDocumentFileID))
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -270,13 +350,18 @@ func TestSendWithExistingDocument(t *testing.T) {
 }
 
 func TestSendWithNewAudio(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewAudio(ChatID, FilePath("tests/audio.mp3"))
 	msg.Title = "TEST"
 	msg.Duration = 10
 	msg.Performer = "TEST"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -284,14 +369,19 @@ func TestSendWithNewAudio(t *testing.T) {
 }
 
 func TestSendWithExistingAudio(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewAudio(ChatID, FileID(ExistingAudioFileID))
 	msg.Title = "TEST"
 	msg.Duration = 10
 	msg.Performer = "TEST"
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -299,11 +389,16 @@ func TestSendWithExistingAudio(t *testing.T) {
 }
 
 func TestSendWithNewVoice(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewVoice(ChatID, FilePath("tests/voice.ogg"))
 	msg.Duration = 10
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -311,11 +406,16 @@ func TestSendWithNewVoice(t *testing.T) {
 }
 
 func TestSendWithExistingVoice(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewVoice(ChatID, FileID(ExistingVoiceFileID))
 	msg.Duration = 10
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -323,19 +423,29 @@ func TestSendWithExistingVoice(t *testing.T) {
 }
 
 func TestSendWithContact(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	contact := NewContact(ChatID, "5551234567", "Test")
 
-	if _, err := bot.Send(contact); err != nil {
+	if _, err = bot.Send(contact); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestSendWithLocation(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
 
-	_, err := bot.Send(NewLocation(ChatID, 40, 40))
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
+
+	_, err = bot.Send(NewLocation(ChatID, 40, 40))
 
 	if err != nil {
 		t.Error(err)
@@ -343,23 +453,33 @@ func TestSendWithLocation(t *testing.T) {
 }
 
 func TestSendWithVenue(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	venue := NewVenue(ChatID, "A Test Location", "123 Test Street", 40, 40)
 
-	if _, err := bot.Send(venue); err != nil {
+	if _, err = bot.Send(venue); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestSendWithNewVideo(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewVideo(ChatID, FilePath("tests/video.mp4"))
 	msg.Duration = 10
 	msg.Caption = "TEST"
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -367,13 +487,18 @@ func TestSendWithNewVideo(t *testing.T) {
 }
 
 func TestSendWithExistingVideo(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewVideo(ChatID, FileID(ExistingVideoFileID))
 	msg.Duration = 10
 	msg.Caption = "TEST"
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -381,12 +506,17 @@ func TestSendWithExistingVideo(t *testing.T) {
 }
 
 func TestSendWithNewVideoNote(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewVideoNote(ChatID, 240, FilePath("tests/videonote.mp4"))
 	msg.Duration = 10
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -394,12 +524,17 @@ func TestSendWithNewVideoNote(t *testing.T) {
 }
 
 func TestSendWithExistingVideoNote(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewVideoNote(ChatID, 240, FileID(ExistingVideoNoteFileID))
 	msg.Duration = 10
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -407,11 +542,16 @@ func TestSendWithExistingVideoNote(t *testing.T) {
 }
 
 func TestSendWithNewSticker(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewSticker(ChatID, FilePath("tests/image.jpg"))
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -419,11 +559,16 @@ func TestSendWithNewSticker(t *testing.T) {
 }
 
 func TestSendWithExistingSticker(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewSticker(ChatID, FileID(ExistingStickerFileID))
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -431,14 +576,19 @@ func TestSendWithExistingSticker(t *testing.T) {
 }
 
 func TestSendWithNewStickerAndKeyboardHide(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewSticker(ChatID, FilePath("tests/image.jpg"))
 	msg.ReplyMarkup = ReplyKeyboardRemove{
 		RemoveKeyboard: true,
 		Selective:      false,
 	}
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -446,7 +596,12 @@ func TestSendWithNewStickerAndKeyboardHide(t *testing.T) {
 }
 
 func TestSendWithExistingStickerAndKeyboardHide(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewSticker(ChatID, FileID(ExistingStickerFileID))
 	msg.ReplyMarkup = ReplyKeyboardRemove{
@@ -454,7 +609,7 @@ func TestSendWithExistingStickerAndKeyboardHide(t *testing.T) {
 		Selective:      false,
 	}
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -462,10 +617,15 @@ func TestSendWithExistingStickerAndKeyboardHide(t *testing.T) {
 }
 
 func TestSendWithDice(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewDice(ChatID)
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -475,10 +635,15 @@ func TestSendWithDice(t *testing.T) {
 }
 
 func TestSendWithDiceWithEmoji(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewDiceWithEmoji(ChatID, "🏀")
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -488,13 +653,18 @@ func TestSendWithDiceWithEmoji(t *testing.T) {
 }
 
 func TestGetFile(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	file := FileConfig{
 		FileID: ExistingPhotoFileID,
 	}
 
-	_, err := bot.GetFile(file)
+	_, err = bot.GetFile(file)
 
 	if err != nil {
 		t.Error(err)
@@ -502,9 +672,14 @@ func TestGetFile(t *testing.T) {
 }
 
 func TestSendChatConfig(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
 
-	_, err := bot.Request(NewChatAction(ChatID, ChatTyping))
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
+
+	_, err = bot.Request(NewChatAction(ChatID, ChatTyping))
 
 	if err != nil {
 		t.Error(err)
@@ -535,16 +710,26 @@ func TestSendChatConfig(t *testing.T) {
 // }
 
 func TestGetUserProfilePhotos(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
 
-	_, err := bot.GetUserProfilePhotos(NewUserProfilePhotos(ChatID))
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
+
+	_, err = bot.GetUserProfilePhotos(NewUserProfilePhotos(ChatID))
 	if err != nil {
 		t.Error(err)
 	}
 }
 
 func TestSetWebhookWithCert(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	time.Sleep(time.Second * 2)
 
@@ -571,7 +756,12 @@ func TestSetWebhookWithCert(t *testing.T) {
 }
 
 func TestSetWebhookWithoutCert(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	time.Sleep(time.Second * 2)
 
@@ -605,7 +795,12 @@ func TestSetWebhookWithoutCert(t *testing.T) {
 }
 
 func TestSendWithMediaGroupPhotoVideo(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	cfg := NewMediaGroup(ChatID, []interface{}{
 		NewInputMediaPhoto(FileURL("https://github.com/go-telegram-bot-api/telegram-bot-api/raw/0a3a1c8716c4cd8d26a262af9f12dcbab7f3f28c/tests/image.jpg")),
@@ -628,7 +823,12 @@ func TestSendWithMediaGroupPhotoVideo(t *testing.T) {
 }
 
 func TestSendWithMediaGroupDocument(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	cfg := NewMediaGroup(ChatID, []interface{}{
 		NewInputMediaDocument(FileURL("https://i.imgur.com/unQLJIb.jpg")),
@@ -650,7 +850,12 @@ func TestSendWithMediaGroupDocument(t *testing.T) {
 }
 
 func TestSendWithMediaGroupAudio(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	cfg := NewMediaGroup(ChatID, []interface{}{
 		NewInputMediaAudio(FilePath("tests/audio.mp3")),
@@ -838,7 +1043,12 @@ func TestDeleteMessage(t *testing.T) {
 }
 
 func TestPinChatMessage(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewMessage(SupergroupChatID, "A test message from the test library in telegram-bot-api")
 	msg.ParseMode = ModeMarkdown
@@ -849,7 +1059,7 @@ func TestPinChatMessage(t *testing.T) {
 		MessageID:           message.MessageID,
 		DisableNotification: false,
 	}
-	_, err := bot.Request(pinChatMessageConfig)
+	_, err = bot.Request(pinChatMessageConfig)
 
 	if err != nil {
 		t.Error(err)
@@ -857,7 +1067,12 @@ func TestPinChatMessage(t *testing.T) {
 }
 
 func TestUnpinChatMessage(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewMessage(SupergroupChatID, "A test message from the test library in telegram-bot-api")
 	msg.ParseMode = ModeMarkdown
@@ -870,7 +1085,7 @@ func TestUnpinChatMessage(t *testing.T) {
 		DisableNotification: false,
 	}
 
-	if _, err := bot.Request(pinChatMessageConfig); err != nil {
+	if _, err = bot.Request(pinChatMessageConfig); err != nil {
 		t.Error(err)
 	}
 
@@ -885,7 +1100,12 @@ func TestUnpinChatMessage(t *testing.T) {
 }
 
 func TestUnpinAllChatMessages(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	msg := NewMessage(SupergroupChatID, "A test message from the test library in telegram-bot-api")
 	msg.ParseMode = ModeMarkdown
@@ -897,7 +1117,7 @@ func TestUnpinAllChatMessages(t *testing.T) {
 		DisableNotification: true,
 	}
 
-	if _, err := bot.Request(pinChatMessageConfig); err != nil {
+	if _, err = bot.Request(pinChatMessageConfig); err != nil {
 		t.Error(err)
 	}
 
@@ -905,13 +1125,18 @@ func TestUnpinAllChatMessages(t *testing.T) {
 		ChatID: message.Chat.ID,
 	}
 
-	if _, err := bot.Request(unpinAllChatMessagesConfig); err != nil {
+	if _, err = bot.Request(unpinAllChatMessagesConfig); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestPolls(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	poll := NewPoll(SupergroupChatID, "Are polls working?", "Yes", "No")
 
@@ -939,7 +1164,12 @@ func TestPolls(t *testing.T) {
 }
 
 func TestSendDice(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	dice := NewDice(ChatID)
 
@@ -954,14 +1184,19 @@ func TestSendDice(t *testing.T) {
 }
 
 func TestCommands(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+		t.FailNow()
+	}
 
 	setCommands := NewSetMyCommands(BotCommand{
 		Command:     "test",
 		Description: "a test command",
 	})
 
-	if _, err := bot.Request(setCommands); err != nil {
+	if _, err = bot.Request(setCommands); err != nil {
 		t.Error("Unable to set commands")
 	}
 
@@ -983,7 +1218,7 @@ func TestCommands(t *testing.T) {
 		Description: "a private command",
 	})
 
-	if _, err := bot.Request(setCommands); err != nil {
+	if _, err = bot.Request(setCommands); err != nil {
 		t.Error("Unable to set commands")
 	}
 

--- a/bot_test.go
+++ b/bot_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	TestToken               = "153667468:AAHlSHlMqSt1f_uFmVRJbm5gntu2HI4WW8I"
+	TestToken = "153667468:AAHlSHlMqSt1f_uFmVRJbm5gntu2HI4WW8I"
+	//TestToken               = "1410306852:AAGHdBp0m4n6a_oUUaPhjxeb4CGrpoka1fQ"
 	ChatID                  = 76918703
 	Channel                 = "@tgbotapitest"
 	SupergroupChatID        = -1001120141283
@@ -36,14 +37,15 @@ func (t testLogger) Printf(format string, v ...interface{}) {
 
 func getBot(t *testing.T) (*BotAPI, error) {
 	bot, err := NewBotAPI(TestToken)
+
+	if err != nil {
+		return nil, err
+	}
+
 	bot.Debug = true
 
 	logger := testLogger{t}
 	SetLogger(logger)
-
-	if err != nil {
-		t.Error(err)
-	}
 
 	return bot, err
 }
@@ -57,11 +59,15 @@ func TestNewBotAPI_notoken(t *testing.T) {
 }
 
 func TestGetUpdates(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	u := NewUpdate(0)
 
-	_, err := bot.GetUpdates(u)
+	_, err = bot.GetUpdates(u)
 
 	if err != nil {
 		t.Error(err)
@@ -69,11 +75,15 @@ func TestGetUpdates(t *testing.T) {
 }
 
 func TestSendWithMessage(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewMessage(ChatID, "A test message from the test library in telegram-bot-api")
 	msg.ParseMode = ModeMarkdown
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -81,11 +91,15 @@ func TestSendWithMessage(t *testing.T) {
 }
 
 func TestSendWithMessageReply(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewMessage(ChatID, "A test message from the test library in telegram-bot-api")
 	msg.ReplyToMessageID = ReplyToMessageID
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -93,10 +107,14 @@ func TestSendWithMessageReply(t *testing.T) {
 }
 
 func TestSendWithMessageForward(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewForward(ChatID, ChatID, ReplyToMessageID)
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -104,7 +122,11 @@ func TestSendWithMessageForward(t *testing.T) {
 }
 
 func TestCopyMessage(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewMessage(ChatID, "A test message from the test library in telegram-bot-api")
 	message, err := bot.Send(msg)
@@ -124,11 +146,15 @@ func TestCopyMessage(t *testing.T) {
 }
 
 func TestSendWithNewPhoto(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewPhoto(ChatID, FilePath("tests/image.jpg"))
 	msg.Caption = "Test"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -136,14 +162,18 @@ func TestSendWithNewPhoto(t *testing.T) {
 }
 
 func TestSendWithNewPhotoWithFileBytes(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	data, _ := os.ReadFile("tests/image.jpg")
 	b := FileBytes{Name: "image.jpg", Bytes: data}
 
 	msg := NewPhoto(ChatID, b)
 	msg.Caption = "Test"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -151,14 +181,18 @@ func TestSendWithNewPhotoWithFileBytes(t *testing.T) {
 }
 
 func TestSendWithNewPhotoWithFileReader(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	f, _ := os.Open("tests/image.jpg")
 	reader := FileReader{Name: "image.jpg", Reader: f}
 
 	msg := NewPhoto(ChatID, reader)
 	msg.Caption = "Test"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -166,12 +200,16 @@ func TestSendWithNewPhotoWithFileReader(t *testing.T) {
 }
 
 func TestSendWithNewPhotoReply(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewPhoto(ChatID, FilePath("tests/image.jpg"))
 	msg.ReplyToMessageID = ReplyToMessageID
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -179,11 +217,15 @@ func TestSendWithNewPhotoReply(t *testing.T) {
 }
 
 func TestSendNewPhotoToChannel(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewPhotoToChannel(Channel, FilePath("tests/image.jpg"))
 	msg.Caption = "Test"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -192,14 +234,18 @@ func TestSendNewPhotoToChannel(t *testing.T) {
 }
 
 func TestSendNewPhotoToChannelFileBytes(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	data, _ := os.ReadFile("tests/image.jpg")
 	b := FileBytes{Name: "image.jpg", Bytes: data}
 
 	msg := NewPhotoToChannel(Channel, b)
 	msg.Caption = "Test"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -208,14 +254,18 @@ func TestSendNewPhotoToChannelFileBytes(t *testing.T) {
 }
 
 func TestSendNewPhotoToChannelFileReader(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	f, _ := os.Open("tests/image.jpg")
 	reader := FileReader{Name: "image.jpg", Reader: f}
 
 	msg := NewPhotoToChannel(Channel, reader)
 	msg.Caption = "Test"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -224,11 +274,15 @@ func TestSendNewPhotoToChannelFileReader(t *testing.T) {
 }
 
 func TestSendWithExistingPhoto(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewPhoto(ChatID, FileID(ExistingPhotoFileID))
 	msg.Caption = "Test"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -236,10 +290,14 @@ func TestSendWithExistingPhoto(t *testing.T) {
 }
 
 func TestSendWithNewDocument(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewDocument(ChatID, FilePath("tests/image.jpg"))
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -247,11 +305,15 @@ func TestSendWithNewDocument(t *testing.T) {
 }
 
 func TestSendWithNewDocumentAndThumb(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewDocument(ChatID, FilePath("tests/voice.ogg"))
 	msg.Thumb = FilePath("tests/image.jpg")
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -259,10 +321,14 @@ func TestSendWithNewDocumentAndThumb(t *testing.T) {
 }
 
 func TestSendWithExistingDocument(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewDocument(ChatID, FileID(ExistingDocumentFileID))
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -270,13 +336,17 @@ func TestSendWithExistingDocument(t *testing.T) {
 }
 
 func TestSendWithNewAudio(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewAudio(ChatID, FilePath("tests/audio.mp3"))
 	msg.Title = "TEST"
 	msg.Duration = 10
 	msg.Performer = "TEST"
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -284,14 +354,18 @@ func TestSendWithNewAudio(t *testing.T) {
 }
 
 func TestSendWithExistingAudio(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewAudio(ChatID, FileID(ExistingAudioFileID))
 	msg.Title = "TEST"
 	msg.Duration = 10
 	msg.Performer = "TEST"
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -299,11 +373,15 @@ func TestSendWithExistingAudio(t *testing.T) {
 }
 
 func TestSendWithNewVoice(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewVoice(ChatID, FilePath("tests/voice.ogg"))
 	msg.Duration = 10
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -311,11 +389,15 @@ func TestSendWithNewVoice(t *testing.T) {
 }
 
 func TestSendWithExistingVoice(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewVoice(ChatID, FileID(ExistingVoiceFileID))
 	msg.Duration = 10
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -323,19 +405,27 @@ func TestSendWithExistingVoice(t *testing.T) {
 }
 
 func TestSendWithContact(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	contact := NewContact(ChatID, "5551234567", "Test")
 
-	if _, err := bot.Send(contact); err != nil {
+	if _, err = bot.Send(contact); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestSendWithLocation(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
 
-	_, err := bot.Send(NewLocation(ChatID, 40, 40))
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
+
+	_, err = bot.Send(NewLocation(ChatID, 40, 40))
 
 	if err != nil {
 		t.Error(err)
@@ -343,23 +433,31 @@ func TestSendWithLocation(t *testing.T) {
 }
 
 func TestSendWithVenue(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	venue := NewVenue(ChatID, "A Test Location", "123 Test Street", 40, 40)
 
-	if _, err := bot.Send(venue); err != nil {
+	if _, err = bot.Send(venue); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestSendWithNewVideo(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewVideo(ChatID, FilePath("tests/video.mp4"))
 	msg.Duration = 10
 	msg.Caption = "TEST"
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -367,13 +465,17 @@ func TestSendWithNewVideo(t *testing.T) {
 }
 
 func TestSendWithExistingVideo(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewVideo(ChatID, FileID(ExistingVideoFileID))
 	msg.Duration = 10
 	msg.Caption = "TEST"
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -381,12 +483,16 @@ func TestSendWithExistingVideo(t *testing.T) {
 }
 
 func TestSendWithNewVideoNote(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewVideoNote(ChatID, 240, FilePath("tests/videonote.mp4"))
 	msg.Duration = 10
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -394,12 +500,16 @@ func TestSendWithNewVideoNote(t *testing.T) {
 }
 
 func TestSendWithExistingVideoNote(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewVideoNote(ChatID, 240, FileID(ExistingVideoNoteFileID))
 	msg.Duration = 10
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -407,11 +517,15 @@ func TestSendWithExistingVideoNote(t *testing.T) {
 }
 
 func TestSendWithNewSticker(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewSticker(ChatID, FilePath("tests/image.jpg"))
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -419,11 +533,15 @@ func TestSendWithNewSticker(t *testing.T) {
 }
 
 func TestSendWithExistingSticker(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewSticker(ChatID, FileID(ExistingStickerFileID))
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -431,14 +549,18 @@ func TestSendWithExistingSticker(t *testing.T) {
 }
 
 func TestSendWithNewStickerAndKeyboardHide(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewSticker(ChatID, FilePath("tests/image.jpg"))
 	msg.ReplyMarkup = ReplyKeyboardRemove{
 		RemoveKeyboard: true,
 		Selective:      false,
 	}
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -446,7 +568,11 @@ func TestSendWithNewStickerAndKeyboardHide(t *testing.T) {
 }
 
 func TestSendWithExistingStickerAndKeyboardHide(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewSticker(ChatID, FileID(ExistingStickerFileID))
 	msg.ReplyMarkup = ReplyKeyboardRemove{
@@ -454,7 +580,7 @@ func TestSendWithExistingStickerAndKeyboardHide(t *testing.T) {
 		Selective:      false,
 	}
 
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -462,10 +588,14 @@ func TestSendWithExistingStickerAndKeyboardHide(t *testing.T) {
 }
 
 func TestSendWithDice(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewDice(ChatID)
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -475,10 +605,14 @@ func TestSendWithDice(t *testing.T) {
 }
 
 func TestSendWithDiceWithEmoji(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewDiceWithEmoji(ChatID, "🏀")
-	_, err := bot.Send(msg)
+	_, err = bot.Send(msg)
 
 	if err != nil {
 		t.Error(err)
@@ -488,13 +622,17 @@ func TestSendWithDiceWithEmoji(t *testing.T) {
 }
 
 func TestGetFile(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	file := FileConfig{
 		FileID: ExistingPhotoFileID,
 	}
 
-	_, err := bot.GetFile(file)
+	_, err = bot.GetFile(file)
 
 	if err != nil {
 		t.Error(err)
@@ -502,9 +640,13 @@ func TestGetFile(t *testing.T) {
 }
 
 func TestSendChatConfig(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
 
-	_, err := bot.Request(NewChatAction(ChatID, ChatTyping))
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
+
+	_, err = bot.Request(NewChatAction(ChatID, ChatTyping))
 
 	if err != nil {
 		t.Error(err)
@@ -535,16 +677,24 @@ func TestSendChatConfig(t *testing.T) {
 // }
 
 func TestGetUserProfilePhotos(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
 
-	_, err := bot.GetUserProfilePhotos(NewUserProfilePhotos(ChatID))
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
+
+	_, err = bot.GetUserProfilePhotos(NewUserProfilePhotos(ChatID))
 	if err != nil {
 		t.Error(err)
 	}
 }
 
 func TestSetWebhookWithCert(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	time.Sleep(time.Second * 2)
 
@@ -571,7 +721,11 @@ func TestSetWebhookWithCert(t *testing.T) {
 }
 
 func TestSetWebhookWithoutCert(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	time.Sleep(time.Second * 2)
 
@@ -605,7 +759,11 @@ func TestSetWebhookWithoutCert(t *testing.T) {
 }
 
 func TestSendWithMediaGroupPhotoVideo(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	cfg := NewMediaGroup(ChatID, []interface{}{
 		NewInputMediaPhoto(FileURL("https://github.com/go-telegram-bot-api/telegram-bot-api/raw/0a3a1c8716c4cd8d26a262af9f12dcbab7f3f28c/tests/image.jpg")),
@@ -628,7 +786,11 @@ func TestSendWithMediaGroupPhotoVideo(t *testing.T) {
 }
 
 func TestSendWithMediaGroupDocument(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	cfg := NewMediaGroup(ChatID, []interface{}{
 		NewInputMediaDocument(FileURL("https://i.imgur.com/unQLJIb.jpg")),
@@ -650,7 +812,11 @@ func TestSendWithMediaGroupDocument(t *testing.T) {
 }
 
 func TestSendWithMediaGroupAudio(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	cfg := NewMediaGroup(ChatID, []interface{}{
 		NewInputMediaAudio(FilePath("tests/audio.mp3")),
@@ -838,7 +1004,11 @@ func TestDeleteMessage(t *testing.T) {
 }
 
 func TestPinChatMessage(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewMessage(SupergroupChatID, "A test message from the test library in telegram-bot-api")
 	msg.ParseMode = ModeMarkdown
@@ -849,7 +1019,7 @@ func TestPinChatMessage(t *testing.T) {
 		MessageID:           message.MessageID,
 		DisableNotification: false,
 	}
-	_, err := bot.Request(pinChatMessageConfig)
+	_, err = bot.Request(pinChatMessageConfig)
 
 	if err != nil {
 		t.Error(err)
@@ -857,7 +1027,11 @@ func TestPinChatMessage(t *testing.T) {
 }
 
 func TestUnpinChatMessage(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewMessage(SupergroupChatID, "A test message from the test library in telegram-bot-api")
 	msg.ParseMode = ModeMarkdown
@@ -870,7 +1044,7 @@ func TestUnpinChatMessage(t *testing.T) {
 		DisableNotification: false,
 	}
 
-	if _, err := bot.Request(pinChatMessageConfig); err != nil {
+	if _, err = bot.Request(pinChatMessageConfig); err != nil {
 		t.Error(err)
 	}
 
@@ -885,7 +1059,11 @@ func TestUnpinChatMessage(t *testing.T) {
 }
 
 func TestUnpinAllChatMessages(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	msg := NewMessage(SupergroupChatID, "A test message from the test library in telegram-bot-api")
 	msg.ParseMode = ModeMarkdown
@@ -897,7 +1075,7 @@ func TestUnpinAllChatMessages(t *testing.T) {
 		DisableNotification: true,
 	}
 
-	if _, err := bot.Request(pinChatMessageConfig); err != nil {
+	if _, err = bot.Request(pinChatMessageConfig); err != nil {
 		t.Error(err)
 	}
 
@@ -905,13 +1083,17 @@ func TestUnpinAllChatMessages(t *testing.T) {
 		ChatID: message.Chat.ID,
 	}
 
-	if _, err := bot.Request(unpinAllChatMessagesConfig); err != nil {
+	if _, err = bot.Request(unpinAllChatMessagesConfig); err != nil {
 		t.Error(err)
 	}
 }
 
 func TestPolls(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	poll := NewPoll(SupergroupChatID, "Are polls working?", "Yes", "No")
 
@@ -939,7 +1121,11 @@ func TestPolls(t *testing.T) {
 }
 
 func TestSendDice(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	dice := NewDice(ChatID)
 
@@ -954,14 +1140,18 @@ func TestSendDice(t *testing.T) {
 }
 
 func TestCommands(t *testing.T) {
-	bot, _ := getBot(t)
+	bot, err := getBot(t)
+
+	if bot == nil {
+		t.Errorf("cannot get bot instance: %v", err)
+	}
 
 	setCommands := NewSetMyCommands(BotCommand{
 		Command:     "test",
 		Description: "a test command",
 	})
 
-	if _, err := bot.Request(setCommands); err != nil {
+	if _, err = bot.Request(setCommands); err != nil {
 		t.Error("Unable to set commands")
 	}
 
@@ -983,7 +1173,7 @@ func TestCommands(t *testing.T) {
 		Description: "a private command",
 	})
 
-	if _, err := bot.Request(setCommands); err != nil {
+	if _, err = bot.Request(setCommands); err != nil {
 		t.Error("Unable to set commands")
 	}
 


### PR DESCRIPTION
Added more informative token error behavior

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
```