### PR TITLE
fix: handle boolean response

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -345,6 +345,16 @@ func (bot *BotAPI) Send(c Chattable) (Message, error) {
 
 	var message Message
 	err = json.Unmarshal(resp.Result, &message)
+	if err == nil {
+		return message, nil
+	}
+
+	var booleanResult bool
+	err = json.Unmarshal(resp.Result, &booleanResult)
+	if err != nil {
+		return message, err
+	}
+	message.BooleanResult = &booleanResult
 
 	return message, err
 }

--- a/types.go
+++ b/types.go
@@ -634,6 +634,8 @@ type Message struct {
 	//
 	// optional
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+
+	BooleanResult *bool `json:"boolean_result,omitempty"`
 }
 
 // Time converts the message timestamp into a Time.


### PR DESCRIPTION
## Issue
In some APIs such as `answerCallbackQuery`, `banchatmember`, telegram server return boolean instead of `Message` struct. It leads to Unmarshal error.

## Releated isssues
- #639 
- #705 

