### PR TITLE
Since Go 1.16, the behavior of go get has changed, and it is no longe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ you want to ask questions or discuss development.
 ## Example
 
 First, ensure the library is installed and up to date by running
-`go get -u github.com/go-telegram-bot-api/telegram-bot-api/v5`.
+`go install github.com/go-telegram-bot-api/telegram-bot-api/v5@latest`.
 
 This is a very simple bot that just displays any gotten updates,
 then replies it to that chat.


### PR DESCRIPTION
…r supported outside of a module. Instead, you should use go install with a version or operate within a module.