### PR TITLE
feat:‌ Add CopyText button to InlineKeyboardButton for text copy functionality

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -745,6 +745,15 @@ func NewInlineKeyboardMarkup(rows ...[]InlineKeyboardButton) InlineKeyboardMarku
 	}
 }
 
+// NewInlineKeyboardButtonCopyText creates an inline keyboard button with text
+// that copies a verification code or other specified text to the clipboard.
+func NewInlineKeyboardButtonCopyText(text string, copyText CopyTextButton) InlineKeyboardButton {
+	return InlineKeyboardButton{
+		Text:     text,
+		CopyText: &copyText,
+	}
+}
+
 // NewCallback creates a new callback message.
 func NewCallback(id, text string) CallbackConfig {
 	return CallbackConfig{

--- a/types.go
+++ b/types.go
@@ -1416,6 +1416,11 @@ type InlineKeyboardButton struct {
 	//
 	// optional
 	SwitchInlineQueryCurrentChat *string `json:"switch_inline_query_current_chat,omitempty"`
+	// CopyText represents an inline keyboard button that copies a verification code
+	// or other specified text to the clipboard.
+	//
+	// optional
+	CopyText *CopyTextButton `json:"copy_text,omitempty"`
 	// CallbackGame description of the game that will be launched when the user presses the button.
 	//
 	// optional
@@ -2112,6 +2117,11 @@ type GameHighScore struct {
 
 // CallbackGame is for starting a game in an inline keyboard button.
 type CallbackGame struct{}
+
+// CopyTextButton is for copy text in an inline keyboard button.
+type CopyTextButton struct {
+	Text string `json:"text"`
+}
 
 // WebhookInfo is information about a currently set webhook.
 type WebhookInfo struct {


### PR DESCRIPTION
### Description:
This PR introduces a new feature to the `InlineKeyboardButton` by adding a `CopyText` button. This button allows the user to copy a verification code or any specified text to the clipboard when clicked. This can be particularly useful for verification processes or other use cases where copying text quickly is required.

### Changes:
- Added `CopyText` field to `InlineKeyboardButton`.
- Created a new function `NewInlineKeyboardButtonCopyText` to simplify the creation of this button with custom text and copy functionality.

### Why:
This feature enhances the user experience by providing a quick way to copy verification codes or other important text without the need to manually select it. It's useful for chatbots or systems that require frequent use of copied data.
