### PR TITLE
Support for supergroup's topics

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -278,6 +278,7 @@ func (chat *BaseChat) params() (Params, error) {
 	params := make(Params)
 
 	params.AddFirstValid("chat_id", chat.ChatID, chat.ChannelUsername)
+	params.AddNonZero("message_thread_id", chat.TopicID)
 	params.AddNonZero("reply_to_message_id", chat.ReplyToMessageID)
 	params.AddBool("disable_notification", chat.DisableNotification)
 	params.AddBool("allow_sending_without_reply", chat.AllowSendingWithoutReply)

--- a/configs.go
+++ b/configs.go
@@ -265,6 +265,7 @@ func (CloseConfig) params() (Params, error) {
 // BaseChat is base type for all chat config types.
 type BaseChat struct {
 	ChatID                   int64 // required
+	TopicID 		 int
 	ChannelUsername          string
 	ProtectContent           bool
 	ReplyToMessageID         int

--- a/helpers.go
+++ b/helpers.go
@@ -14,10 +14,16 @@ import (
 // NewMessage creates a new Message.
 //
 // chatID is where to send it, text is the message text.
-func NewMessage(chatID int64, text string) MessageConfig {
+// topicID is additional parameter to specify topic of supergroup where message need to be sent.
+func NewMessage(chatID int64, text string, topicID ...int) MessageConfig {
+	threadID := 0
+	if len(topicID) > 0 {
+		threadID = topicID[0]
+	}
 	return MessageConfig{
 		BaseChat: BaseChat{
 			ChatID:           chatID,
+			TopicID:          threadID,
 			ReplyToMessageID: 0,
 		},
 		Text:                  text,

--- a/types.go
+++ b/types.go
@@ -361,6 +361,10 @@ func (c Chat) ChatConfig() ChatConfig {
 type Message struct {
 	// MessageID is a unique message identifier inside this chat
 	MessageID int `json:"message_id"`
+	// TopicID is id of topic in which message was sent
+	//
+	// optional, supergroups only
+	TopicID int `json:"message_thread_id",omitempty`
 	// From is a sender, empty for messages sent to channels;
 	//
 	// optional


### PR DESCRIPTION
Added TopicID to Message struct

NewMessage func now have additional param - TopicID which defines to which topic to send message. This change is implemented by adding new field to BaseChat struct.